### PR TITLE
Load just the characters needed by each TachyFont family/weight.

### DIFF
--- a/run_time/src/gae_server/chrome/js/tachyfont.js
+++ b/run_time/src/gae_server/chrome/js/tachyfont.js
@@ -208,7 +208,9 @@ tachyfont.TachyFontSet.prototype.addTextToFontGroups =
   // Look for this in the font set.
   var index = tachyFontSet.fontIdToIndex[fontId];
   if (index == undefined) {
-    console.log('did not find = ' + fontId);
+    if (goog.DEBUG) {
+      goog.log.log(tachyfont.logger_, 'did not find = ' + fontId);
+    }
     return;
   }
 


### PR DESCRIPTION
Previously every TachyFont loaded all the chars on the page.