### PR TITLE
Use family name instead of font name when requesting data.

### DIFF
--- a/run_time/src/gae_server/chrome/js/tachyfont.js
+++ b/run_time/src/gae_server/chrome/js/tachyfont.js
@@ -2713,7 +2713,7 @@ tachyfont.GoogleBackendService.prototype.log = function(message) {
  */
 tachyfont.GoogleBackendService.prototype.getUrl_ = function(
     fontInfo, prefix, suffix) {
-  var family = fontInfo['name'].replace(' ', '').toLowerCase();
+  var family = fontInfo['familyName'].replace(/ /g, '').toLowerCase();
   return this.baseUrl + '/' + prefix + '/' + family + '/' +
       fontInfo['version'] + '/' + fontInfo['fontkit'] + '.' + suffix;
 };

--- a/run_time/src/gae_server/chrome/js/tachyfont.js
+++ b/run_time/src/gae_server/chrome/js/tachyfont.js
@@ -2706,7 +2706,10 @@ tachyfont.GoogleBackendService.prototype.log = function(message) {
 
 /**
  * @private
- * @param {Object} fontInfo Info on the font.
+ * @param {Object} fontInfo Metadata for the font including weight, version, fontkit,
+*                  familyName = Full font family name, not compressed ie. "Noto Sans", and
+*                  name = Unique name for this particular instance of the font (style/weight)
+*                  ie. "notosans100".
  * @param {string} prefix Action prefix in the URL.
  * @param {string} suffix Action suffset in the URL.
  * @return {string} URL for the specified font action.


### PR DESCRIPTION
This allows the font name to be varied per weight.