### PR TITLE
Move the tachyfont.BinaryFontEditor out of tachyfont.js and into a separate file.

### DIFF
--- a/run_time/src/gae_server/chrome/js/closure_deps.js
+++ b/run_time/src/gae_server/chrome/js/closure_deps.js
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+//debugger;
+goog.addDependency('../../../binaryfonteditor.js',
+    ['tachyfont.BinaryFontEditor'],
+    []);


### PR DESCRIPTION
It currently defines tachyfont.BinaryFontEditor.