### PR TITLE
Format 4 fixes: use the correct index when setting the glyph Id and

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/incrementalfontutils.js
+++ b/run_time/src/gae_server/www/js/tachyfont/incrementalfontutils.js
@@ -580,8 +580,19 @@ tachyfont.IncrementalFontUtils.setFormat4GlyphIds_ =
       continue;
     }
     var format4Seg = charCmapInfo.format4Seg;
+    if (format4Seg == null) {
+      if (goog.DEBUG) {
+        if (code <= 0xFFFF) {
+          goog.log.error(tachyfont.logger,
+            'format 4, missine segment for code ' + code);
+          debugger;
+        }
+      }
+      // Character is not in the format 4 segment.
+      continue;
+    }
     binEd.seek(idDeltaOffset + format4Seg * 2);
-    binEd.setUint16(segments[i][2]);
+    binEd.setUint16(segments[format4Seg][2]);
   }
 
 };


### PR DESCRIPTION
ignore characters above 0xFFFF.