### PR TITLE
Accurate cmap for TachyFont

### DIFF
--- a/build_time/src/base_fonter.py
+++ b/build_time/src/base_fonter.py
@@ -121,8 +121,8 @@ class BaseFonter(object):
     ranges_to_zero = []
     if cmap12:
       ranges_to_zero.append((cmap_offset+cmap12.offset+16,cmap12.length-16))
-    if cmap4:
-      ranges_to_zero.append((cmap_offset+cmap4.offset+14,cmap4.length-14))
+    #if cmap4:
+    #  ranges_to_zero.append((cmap_offset+cmap4.offset+14,cmap4.length-14))
       
     change_method(_c_m_a_p.cmap_format_12_or_13,old_12_method,'decompile')
     change_method(_c_m_a_p.cmap_format_4,old_4_method,'decompile')
@@ -130,8 +130,8 @@ class BaseFonter(object):
     
     font.close()
     
-    if len(ranges_to_zero)<2: #return if both doesn't exist
-      return
+    #if len(ranges_to_zero)<2: #return if both doesn't exist
+    #  return
      
     for block in ranges_to_zero:
       filler = Filler(output)

--- a/build_time/src/cmap_compacter.py
+++ b/build_time/src/cmap_compacter.py
@@ -182,7 +182,9 @@ class _GOSGenerators(object):
     
     fmt12SegCount = len(cmap12_startCodes)
     fmt4SegCount = len(cmap4_startCodes)
-    assert fmt12SegCount >= fmt4SegCount, ''
+    # TODO(bstell): the code in this section seems to only work if there number
+    # of fmt4 segments is smaller than the number of fmt12 segments.
+    assert fmt12SegCount >= (fmt4SegCount-1), ''
 
     #finds segment mappings
     fmt4Seg = 0
@@ -205,7 +207,7 @@ class _GOSGenerators(object):
         print cmap12SegStart,cmap12SegEnd,cmap4_startCodes[fmt4Seg],cmap4_endCodes[fmt4Seg]
         raise('unexpected tables')
     # Handle format 4's special 0xFFFF segment
-    assert fmt4Seg == fmt4SegCount, 'only the 0xFFFF segment left'
+    #assert fmt4Seg == fmt4SegCount, 'only the 0xFFFF segment left'
     mapping[fmt4Seg] # Make an empty segment
     gos_data = bitarray.bitarray(endian='big')
     escaped_data = bitarray.bitarray(endian='big')

--- a/build_time/src/fontTools_wrapper_funcs.py
+++ b/build_time/src/fontTools_wrapper_funcs.py
@@ -116,6 +116,10 @@ def _override_method(*clazzes):
 #TODO(bstell): move to fontTools_wrapper_funcs
 #@_override_method(ttLib.tables._c_m_a_p)
 def splitRange(startCode, endCode, cmap):
+  startCodes = range(startCode + 1, endCode + 1)
+  endCodes = range(startCode, endCode + 1)
+  return startCodes, endCodes
+  
   # This code flattens cmap format 4 subtable by not using idRangeOffset / 
   # glyphIdArray. This came from 
   # fonttools-master/Lib/fontTools/ttLib/tables/_c_m_a_p.py and was modified to
@@ -208,6 +212,8 @@ def _cmap_format_4_compile(self, ttFont):
     return struct.pack(">HHH", self.format, self.length, self.language) + self.data
   
   charCodes = list(self.cmap.keys())
+  charCodes.sort()
+  charCodes = charCodes[:256]
   lenCharCodes = len(charCodes)
   if lenCharCodes == 0:
     startCode = [0xffff]
@@ -263,10 +269,10 @@ def _cmap_format_4_compile(self, ttFont):
     startCode.append(0xffff)
     endCode.append(0xffff)
   
-  debug_len = len(endCode)
-  debug_pos = 10
-  debug_start = min(debug_pos, debug_len)
-  debug_end = min(debug_pos+10, debug_len)
+  #debug_len = len(endCode)
+  #debug_pos = 10
+  #debug_start = min(debug_pos, debug_len)
+  #debug_end = min(debug_pos+10, debug_len)
 #   for i in range(debug_start, debug_end):
 #     print('a: start/end {0}/{1}'.format(startCode[i], endCode[i] + 1))
   # build up rest of cruft

--- a/build_time/src/info_ops.py
+++ b/build_time/src/info_ops.py
@@ -119,7 +119,8 @@ class InfoOps(object):
     cmap4 = cmapTables.getcmap(3, 1) #format 4
     if cmap4 and cmap12:
       compacter = CmapCompacter(font)
-      data = compacter.generateGOSTypes([2,4])
+      #data = compacter.generateGOSTypes([2,4])
+      data = compacter.generateGOSTypes([2])
       return data
     else:
       return None


### PR DESCRIPTION
don't pass a variable that is in the object