### PR TITLE
Report when the fonts are available to page (setFont finishes).

### DIFF
--- a/run_time/src/gae_server/www/js/closure_deps.js
+++ b/run_time/src/gae_server/www/js/closure_deps.js
@@ -58,11 +58,17 @@ goog.addDependency('../../../tachyfont/rledecoder.js',
 goog.addDependency('../../../tachyfont/tachyfontpromise.js',
     ['tachyfont.promise', 'tachyfont.chainedPromises'],
     ['goog.Promise']);
+goog.addDependency('../../../tachyfont/tachyfontreporter.js',
+    ['tachyfont.reporter'],
+    ['goog.log']);
 goog.addDependency('../../../tachyfont/tachyfontset.js',
     ['tachyfont.TachyFontSet'],
     ['goog.array', 'goog.Promise', 'goog.log', 'goog.style',
      'tachyfont.IncrementalFontUtils', 'tachyfont.chainedPromises'
     ]);
+goog.addDependency('../../../tachyfont/tachyfontutils.js',
+    ['tachyfont.utils'],
+    ['goog.crypt.Md5']);
 goog.addDependency('../../../tachyfont/webfonttailor.js',
     ['webfonttailor'],
     ['tachyfont.FontInfo',


### PR DESCRIPTION
Move the code that builds a fallback url into tachyfont.js (where the
fonts are handled as a set).