### PR TITLE
Change most time reporting to relative to start of TachyFont or char data available.

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/incrementalfont.js
+++ b/run_time/src/gae_server/www/js/tachyfont/incrementalfont.js
@@ -139,10 +139,6 @@ tachyfont.IncrementalFont.LOG_MISS_COUNT_ = 'mc';
 tachyfont.IncrementalFont.LOG_MISS_RATE_ = 'mr';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.LOG_TIME_BUCKET_SIZE_ = 50;
-
-
 /**
  * The reportError constants.
  */
@@ -352,9 +348,9 @@ tachyfont.IncrementalFont.createManager = function(fontInfo, params) {
   */
   incrFontMgr.getIDB_ = incrFontMgr.openIndexedDB(fontName);
   incrFontMgr.getIDB_.then(function() {
-        tachyfont.reporter.addItemTime(
+        tachyfont.reporter.addItem(
             tachyfont.IncrementalFont.LOG_OPEN_IDB_ + weight,
-            tachyfont.IncrementalFont.LOG_TIME_BUCKET_SIZE_);
+            goog.now() - incrFontMgr.startTime_);
       });
   //tachyfont.timer1.end('openIndexedDB.open ' + fontName);
 
@@ -385,9 +381,9 @@ tachyfont.IncrementalFont.createManager = function(fontInfo, params) {
         return {};
       }).
       then(function(charlist_data) {
-        tachyfont.reporter.addItemTime(
+        tachyfont.reporter.addItem(
             tachyfont.IncrementalFont.LOG_IDB_GET_CHARLIST_ + weight,
-            tachyfont.IncrementalFont.LOG_TIME_BUCKET_SIZE_);
+            goog.now() - incrFontMgr.startTime_);
         return charlist_data;
         // }).thenCatch(function(e) {
         //   tachyfont.IncrementalFont.reportError_( 20, weight, e);
@@ -420,6 +416,13 @@ tachyfont.IncrementalFont.createManager = function(fontInfo, params) {
  * @private
  */
 tachyfont.IncrementalFont.obj_ = function(fontInfo, params, backendService) {
+  /**
+   * The creation time for this TachyFont.
+   *
+   * @private {number}
+   */
+  this.startTime_ = goog.now();
+
   /**
    * Information about the fonts
    *
@@ -531,10 +534,8 @@ tachyfont.IncrementalFont.obj_.prototype.getPersistedBase = function() {
         return goog.Promise.all([goog.Promise.resolve(idb), filedata]);
       }.bind(this)).
       then(function(arr) {
-        tachyfont.reporter.addItemTime(
-            tachyfont.IncrementalFont.LOG_IDB_GET_BASE_ +
-            this.fontInfo.getWeight(),
-            tachyfont.IncrementalFont.LOG_TIME_BUCKET_SIZE_);
+        tachyfont.reporter.addItem(tachyfont.IncrementalFont.LOG_IDB_GET_BASE_ +
+            this.fontInfo.getWeight(), goog.now() - this.startTime_);
         var idb = arr[0];
         var filedata = new DataView(arr[1]);
         this.parseBaseHeader(filedata);
@@ -562,9 +563,8 @@ tachyfont.IncrementalFont.obj_.prototype.parseBaseHeader =
   var binEd = new tachyfont.BinaryFontEditor(baseFontView, 0);
   var fileInfo = binEd.parseBaseHeader();
   if (!fileInfo.headSize) {
-    tachyfont.reporter.addItemTime(
-        tachyfont.IncrementalFont.LOG_PARSE_HEADER_ + this.fontInfo.getWeight(),
-        tachyfont.IncrementalFont.LOG_TIME_BUCKET_SIZE_);
+    tachyfont.reporter.addItem(tachyfont.IncrementalFont.LOG_PARSE_HEADER_ +
+      this.fontInfo.getWeight(), goog.now() - incrFontMgr.startTime_);
     throw 'missing header info';
   }
   this.fileInfo_ = fileInfo;
@@ -583,10 +583,8 @@ tachyfont.IncrementalFont.obj_.prototype.getUrlBase =
     function(backendService, fontInfo) {
   var rslt = backendService.requestFontBase(fontInfo).
       then(function(fetchedBytes) {
-        tachyfont.reporter.addItemTime(
-            tachyfont.IncrementalFont.LOG_URL_GET_BASE_ +
-            this.fontInfo.getWeight(),
-            tachyfont.IncrementalFont.LOG_TIME_BUCKET_SIZE_);
+        tachyfont.reporter.addItem(tachyfont.IncrementalFont.LOG_URL_GET_BASE_ +
+            this.fontInfo.getWeight(), goog.now() - incrFontMgr.startTime_);
         var results = this.processUrlBase_(fetchedBytes);
         this.persistDelayed_(tachyfont.IncrementalFont.BASE);
         return results;

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfont.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfont.js
@@ -252,15 +252,7 @@ tachyfont.LOG_LOAD_FONTS_WAIT_PREVIOUS_ = 'lfw';
 
 
 /** @private {string} */
-tachyfont.LOG_LOAD_FONTS_BEGIN_ = 'lfb';
-
-
-/** @private {string} */
 tachyfont.LOG_SWITCH_FONT_ = 'sfe';
-
-
-/** @private {number} */
-tachyfont.LOG_TIME_BUCKET_SIZE_ = 50;
 
 
 /** @private {string} */
@@ -382,13 +374,14 @@ tachyfont.loadFonts = function(familyName, fontsInfo, opt_params) {
         'loadFonts: wait for preceding update');
     msg = 'loadFonts';
   }
-  tachyfont.reporter.addItemTime(tachyfont.LOG_LOAD_FONTS_WAIT_PREVIOUS_);
+  var waitPreviousTime = goog.now();
   var allLoaded = tachyFontSet.finishPrecedingUpdateFont.getChainedPromise(msg);
   // TODO(bstell): this call 'getPrecedingPromise' should be the return from the
   // getChainedPromise. getChainedPromise should be waitForPrecedingPromise.
   allLoaded.getPrecedingPromise().
       then(function() {
-        tachyfont.reporter.addItemTime(tachyfont.LOG_LOAD_FONTS_BEGIN_);
+        tachyfont.reporter.addItem(tachyfont.LOG_LOAD_FONTS_WAIT_PREVIOUS_,
+          '000', goog.now() - waitPreviousTime);
         if (goog.DEBUG) {
           goog.log.log(tachyfont.logger, goog.log.Level.FINER,
               'loadFonts: done waiting for preceding update');
@@ -447,9 +440,8 @@ tachyfont.loadFonts = function(familyName, fontsInfo, opt_params) {
                 then(function() {
                   // Report Set Font Early.
                   var weight = this.fontInfo.getWeight();
-                  tachyfont.reporter.addItemTime(
-                      tachyfont.LOG_SWITCH_FONT_ + weight,
-                      tachyfont.LOG_TIME_BUCKET_SIZE_);
+                  tachyfont.reporter.addItem(tachyfont.LOG_SWITCH_FONT_ +
+                    weight, goog.now() - incrFont.startTime_);
                   var deltaTime = goog.now() - this.sfeStart_;
                   tachyfont.reporter.addItem(
                       tachyfont.LOG_SWITCH_FONT_DELTA_TIME_ + weight,
@@ -564,7 +556,7 @@ tachyfont.loadFonts = function(familyName, fontsInfo, opt_params) {
       if (goog.DEBUG) {
         goog.log.info(tachyfont.logger, 'DOMContentLoaded: updateFonts');
       }
-      tachyFontSet.updateFonts(true);
+      tachyFontSet.updateFonts(0, true);
     } else {
       // The mutation event should be very soon.
       if (goog.DEBUG) {
@@ -578,30 +570,30 @@ tachyfont.loadFonts = function(familyName, fontsInfo, opt_params) {
 };
 
 
-/**
- * Update a list of TachyFonts
- *
- * TODO(bstell): remove the tachyfont.TachyFont type.
- * @param {Array.<tachyfont.TachyFont>|tachyfont.TachyFontSet} tachyFonts The
- *     list of font objects.
- */
-tachyfont.updateFonts = function(tachyFonts) {
-  if (tachyFonts.constructor == Array) {
-    if (goog.DEBUG) {
-      goog.log.info(tachyfont.logger,
-          'tachyfont.updateFonts: passing in an array is deprecated');
-    }
-    for (var i = 0; i < tachyFonts.length; i++) {
-      var tachyFont = tachyFonts[i];
-      tachyFont.incrfont.loadChars();
-    }
-  } else if (tachyFonts.constructor == tachyfont.TachyFontSet) {
-    if (goog.DEBUG) {
-      goog.log.info(tachyfont.logger, 'tachyfont.updateFonts');
-    }
-    tachyFonts.updateFonts(true);
-  }
-};
+///**
+// * Update a list of TachyFonts
+// *
+// * TODO(bstell): remove the tachyfont.TachyFont type.
+// * @param {Array.<tachyfont.TachyFont>|tachyfont.TachyFontSet} tachyFonts The
+// *     list of font objects.
+// */
+//tachyfont.updateFonts = function(tachyFonts) {
+//  if (tachyFonts.constructor == Array) {
+//    if (goog.DEBUG) {
+//      goog.log.info(tachyfont.logger,
+//          'tachyfont.updateFonts: passing in an array is deprecated');
+//    }
+//    for (var i = 0; i < tachyFonts.length; i++) {
+//      var tachyFont = tachyFonts[i];
+//      tachyFont.incrfont.loadChars();
+//    }
+//  } else if (tachyFonts.constructor == tachyfont.TachyFontSet) {
+//    if (goog.DEBUG) {
+//      goog.log.info(tachyfont.logger, 'tachyfont.updateFonts');
+//    }
+//    tachyFonts.updateFonts(true);
+//  }
+//};
 
 
 /**

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfontreporter.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfontreporter.js
@@ -85,14 +85,9 @@ tachyfont.Reporter.getReporter = function(url) {
  * Add the time an item happened.
  *
  * @param {string} name The name of the item.
- * @param {number=} opt_roundTo Optionally round to this number.
  */
-tachyfont.Reporter.prototype.addItemTime = function(name, opt_roundTo) {
+tachyfont.Reporter.prototype.addItemTime = function(name) {
   var deltaTime = goog.now() - tachyfont.Reporter.startTime_;
-  // Round to the time to groups to make the graph more useful.
-  if (typeof opt_roundTo == 'number' && opt_roundTo > 1) {
-    deltaTime = Math.round(deltaTime / opt_roundTo) * opt_roundTo;
-  }
   this.addItem(name, deltaTime);
 };
 
@@ -104,14 +99,6 @@ tachyfont.Reporter.prototype.addItemTime = function(name, opt_roundTo) {
  * @param {string|number} value The value of the item.
  */
 tachyfont.Reporter.prototype.addItem = function(name, value) {
-  if (name in this.dupCnts_) {
-    var dupCnt = this.dupCnts_[name] + 1;
-    this.dupCnts_[name] = dupCnt;
-    name += '.' + dupCnt;
-  } else {
-    this.dupCnts_[name] = 0;
-  }
-
   if (typeof value == 'number') {
     value = Math.round(value);
   }

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfontset.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfontset.js
@@ -115,7 +115,7 @@ tachyfont.TachyFontSet = function(familyName) {
 
 
 /**
- * The addItem/addItemTime constants.
+ * The addItem constants.
  */
 /** @private {string} */
 tachyfont.TachyFontSet.LOG_SET_FONT_ = 'sf';
@@ -125,8 +125,8 @@ tachyfont.TachyFontSet.LOG_SET_FONT_ = 'sf';
 tachyfont.TachyFontSet.LOG_SET_FONT_DELAYED_ = 'sfd';
 
 
-/** @private {number} */
-tachyfont.TachyFontSet.LOG_TIME_BUCKET_SIZE_ = 50;
+/** @private {string} */
+tachyfont.TachyFontSet.LOG_SET_FONT_DOM_LOADED_ = 'sfl';
 
 
 /**
@@ -524,7 +524,12 @@ tachyfont.TachyFontSet.prototype.updateFonts =
           }
           var cssSetResult = fontObj.setFont(fontData, fileInfo).
               then(function() {
-                if (startTime >= 0) {
+                if (startTime == 0) {
+                  tachyfont.reporter.addItemTime(
+                    tachyfont.TachyFontSet.LOG_SET_DOM_LOADED_ +
+                    this.fontInfo.getWeight());
+                  
+                } else if (startTime >= 0) {
                   tachyfont.reporter.addItem(
                     tachyfont.TachyFontSet.LOG_SET_FONT_ +
                     this.fontInfo.getWeight(),


### PR DESCRIPTION
Report the time from TachyFont creation to switching the font for DOMContentLoaded.
Remove the duplicate count number from the logging and errors.
Remove bucketizing.
Remove the deprecated tachyfont.updateFonts call.
