### PR TITLE
Make the logging and error name parameters more legible.

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/incrementalfont.js
+++ b/run_time/src/gae_server/www/js/tachyfont/incrementalfont.js
@@ -112,155 +112,159 @@ tachyfont.IncrementalFont.CHARLIST_DIRTY = 'charlist_dirty';
  * The addItem/addItemTime constants.
  */
 /** @private {string} */
-tachyfont.IncrementalFont.LOG_OPEN_IDB_ = 'oi';
+tachyfont.IncrementalFont.CREATE_TACHYFONT_ = 'LIFCT.';
 
 
 /** @private {string} */
-tachyfont.IncrementalFont.LOG_IDB_GET_CHARLIST_ = 'ic';
+tachyfont.IncrementalFont.LOG_OPEN_IDB_ = 'LIFOI.';
 
 
 /** @private {string} */
-tachyfont.IncrementalFont.LOG_IDB_GET_BASE_ = 'ib';
+tachyfont.IncrementalFont.LOG_IDB_GET_CHARLIST_ = 'LIFIC.';
 
 
 /** @private {string} */
-tachyfont.IncrementalFont.LOG_PARSE_HEADER_ = 'ph';
+tachyfont.IncrementalFont.LOG_IDB_GET_BASE_ = 'LIFIB.';
 
 
 /** @private {string} */
-tachyfont.IncrementalFont.LOG_URL_GET_BASE_ = 'ub';
+tachyfont.IncrementalFont.LOG_PARSE_HEADER_ = 'LIFPH.';
 
 
 /** @private {string} */
-tachyfont.IncrementalFont.LOG_MISS_COUNT_ = 'mc';
+tachyfont.IncrementalFont.LOG_URL_GET_BASE_ = 'LIFUB.';
 
 
 /** @private {string} */
-tachyfont.IncrementalFont.LOG_MISS_RATE_ = 'mr';
+tachyfont.IncrementalFont.LOG_MISS_COUNT_ = 'LIFMC.';
+
+
+/** @private {string} */
+tachyfont.IncrementalFont.LOG_MISS_RATE_ = 'LIFMR.';
 
 
 /**
  * The reportError constants.
  */
 /** @private {string} */
-tachyfont.IncrementalFont.ERROR_FILE_ID_ = 'if';
+tachyfont.IncrementalFont.ERROR_FILE_ID_ = 'EIF';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_WRITE_CMAP4_SEGMENT_COUNT_ = 1;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_WRITE_CMAP4_SEGMENT_COUNT_ = '01.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_FORMAT4_GLYPH_IDS_SEGMENT_COUNT_ = 2;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_FORMAT4_GLYPH_IDS_SEGMENT_COUNT_ = '02.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_FORMAT4_GLYPH_IDS_END_CODE_ = 3;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_FORMAT4_GLYPH_IDS_END_CODE_ = '03.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_FORMAT4_GLYPH_IDS_SEGMENT_LENGTH_ = 4;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_FORMAT4_GLYPH_IDS_SEGMENT_LENGTH_ = '04.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_FORMAT4_GLYPH_IDS_START_CODE_ = 5;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_FORMAT4_GLYPH_IDS_START_CODE_ = '05.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_FORMAT4_GLYPH_IDS_ALREADY_SET_ = 6;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_FORMAT4_GLYPH_IDS_ALREADY_SET_ = '06.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_FORMAT4_GLYPH_IDS_ID_RANGE_OFFSET_ = 7;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_FORMAT4_GLYPH_IDS_ID_RANGE_OFFSET_ = '07.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_FORMAT4_GLYPH_IDS_CHAR_CMAP_INFO_ = 8;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_FORMAT4_GLYPH_IDS_CHAR_CMAP_INFO_ = '08.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_FORMAT4_GLYPH_IDS_SEGMENT_ = 9;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_FORMAT4_GLYPH_IDS_SEGMENT_ = '09.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_FORMAT12_GLYPH_IDS_CHAR_CMAP_INFO_ = 10;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_FORMAT12_GLYPH_IDS_CHAR_CMAP_INFO_ = '10.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_FORMAT12_GLYPH_IDS_START_CODE_ = 11;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_FORMAT12_GLYPH_IDS_START_CODE_ = '11.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_FORMAT12_GLYPH_IDS_END_CODE_ = 12;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_FORMAT12_GLYPH_IDS_END_CODE_ = '12.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_FORMAT12_GLYPH_IDS_SEGMENT_LENGTH_ = 13;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_FORMAT12_GLYPH_IDS_SEGMENT_LENGTH_ = '13.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_FORMAT12_GLYPH_IDS_ALREADY_SET_ = 14;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_FORMAT12_GLYPH_IDS_ALREADY_SET_ = '14.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_FORMAT12_GLYPH_IDS_MISMATCH_ = 15;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_FORMAT12_GLYPH_IDS_MISMATCH_ = '15.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_LOAD_CHARS_INJECT_CHARS_ = 16;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_LOAD_CHARS_INJECT_CHARS_ = '16.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_LOAD_CHARS_INJECT_CHARS_2_ = 17;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_LOAD_CHARS_INJECT_CHARS_2_ = '17.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_LOAD_CHARS_GET_LOCK_ = 18;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_LOAD_CHARS_GET_LOCK_ = '18.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_PERSIST_SAVE_DATA_ = 19;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_PERSIST_SAVE_DATA_ = '19.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_PERSIST_GET_LOCK_ = 21;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_PERSIST_GET_LOCK_ = '21.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_SAVE_DATA_ = 22;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_SAVE_DATA_ = '22.';
 
-// /* * @private {number} */
-// tachyfont.IncrementalFont.ERROR_SAVE_DATA_2_ = 23;
-
-
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_SAVE_DATA_GET_IDB_ = 24;
+// /* * @private {string} */
+// tachyfont.IncrementalFont.ERROR_SAVE_DATA_2_ = '23.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_OPEN_IDB_ = 25;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_SAVE_DATA_GET_IDB_ = '24.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_IDB_ON_UPGRAGE_NEEDED_ = 26;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_OPEN_IDB_ = '25.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_GET_DATA_ = 27;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_IDB_ON_UPGRAGE_NEEDED_ = '26.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_CMAP4_CHARS_PER_SEGMENT_ = 28;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_GET_DATA_ = '27.';
 
 
-/** @private {number} */
-tachyfont.IncrementalFont.ERROR_CMAP12_CHARS_PER_SEGMENT_ = 29;
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_CMAP4_CHARS_PER_SEGMENT_ = '28.';
+
+
+/** @private {string} */
+tachyfont.IncrementalFont.ERROR_CMAP12_CHARS_PER_SEGMENT_ = '29.';
 
 
 /**
  * The error reporter for this file.
  *
- * @param {number} errNum The error number;
+ * @param {string} errNum The error number;
  * @param {string} errId Identifies the error.
  * @param {*} errInfo The error object;
  * @private
@@ -331,6 +335,9 @@ tachyfont.IncrementalFont.createManager = function(fontInfo, params) {
   // }
   var incrFontMgr =
       new tachyfont.IncrementalFont.obj_(fontInfo, params, backendService);
+  tachyfont.reporter.addItem(
+      tachyfont.IncrementalFont.CREATE_TACHYFONT_ + weight,
+      goog.now() - incrFontMgr.startTime);
   //tachyfont.timer1.start('openIndexedDB.open ' + fontName);
   //  tachyfont.IncrementalFontUtils.logger(incrFontMgr.url,
   //    'need to report info');
@@ -350,7 +357,7 @@ tachyfont.IncrementalFont.createManager = function(fontInfo, params) {
   incrFontMgr.getIDB_.then(function() {
         tachyfont.reporter.addItem(
             tachyfont.IncrementalFont.LOG_OPEN_IDB_ + weight,
-            goog.now() - incrFontMgr.startTime_);
+            goog.now() - incrFontMgr.startTime);
       });
   //tachyfont.timer1.end('openIndexedDB.open ' + fontName);
 
@@ -383,7 +390,7 @@ tachyfont.IncrementalFont.createManager = function(fontInfo, params) {
       then(function(charlist_data) {
         tachyfont.reporter.addItem(
             tachyfont.IncrementalFont.LOG_IDB_GET_CHARLIST_ + weight,
-            goog.now() - incrFontMgr.startTime_);
+            goog.now() - incrFontMgr.startTime);
         return charlist_data;
         // }).thenCatch(function(e) {
         //   tachyfont.IncrementalFont.reportError_( 20, weight, e);
@@ -419,9 +426,9 @@ tachyfont.IncrementalFont.obj_ = function(fontInfo, params, backendService) {
   /**
    * The creation time for this TachyFont.
    *
-   * @private {number}
+   * @type {number}
    */
-  this.startTime_ = goog.now();
+  this.startTime = goog.now();
 
   /**
    * Information about the fonts
@@ -535,7 +542,7 @@ tachyfont.IncrementalFont.obj_.prototype.getPersistedBase = function() {
       }.bind(this)).
       then(function(arr) {
         tachyfont.reporter.addItem(tachyfont.IncrementalFont.LOG_IDB_GET_BASE_ +
-            this.fontInfo.getWeight(), goog.now() - this.startTime_);
+            this.fontInfo.getWeight(), goog.now() - this.startTime);
         var idb = arr[0];
         var filedata = new DataView(arr[1]);
         this.parseBaseHeader(filedata);
@@ -564,7 +571,7 @@ tachyfont.IncrementalFont.obj_.prototype.parseBaseHeader =
   var fileInfo = binEd.parseBaseHeader();
   if (!fileInfo.headSize) {
     tachyfont.reporter.addItem(tachyfont.IncrementalFont.LOG_PARSE_HEADER_ +
-      this.fontInfo.getWeight(), goog.now() - incrFontMgr.startTime_);
+        this.fontInfo.getWeight(), goog.now() - this.startTime);
     throw 'missing header info';
   }
   this.fileInfo_ = fileInfo;
@@ -584,7 +591,7 @@ tachyfont.IncrementalFont.obj_.prototype.getUrlBase =
   var rslt = backendService.requestFontBase(fontInfo).
       then(function(fetchedBytes) {
         tachyfont.reporter.addItem(tachyfont.IncrementalFont.LOG_URL_GET_BASE_ +
-            this.fontInfo.getWeight(), goog.now() - incrFontMgr.startTime_);
+            this.fontInfo.getWeight(), goog.now() - this.startTime);
         var results = this.processUrlBase_(fetchedBytes);
         this.persistDelayed_(tachyfont.IncrementalFont.BASE);
         return results;

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfont.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfont.js
@@ -53,8 +53,7 @@ window.onerror =
     errorObj['message'] = errorMsg;
     errorObj['url'] = url;
     errorObj['lineNumber'] = lineNumber;
-    tachyfont.reportError_(tachyfont.ERROR_WINDOW_ON_ERROR_, '000',
-        errorObj);
+    tachyfont.reportError_(tachyfont.ERROR_WINDOW_ON_ERROR_, errorObj);
   }
 
   if (goog.DEBUG) {
@@ -244,56 +243,54 @@ tachyfont.initializeReporter = function(url) {
  * The addItem/addItemTime constants.
  */
 /** @private {string} */
-tachyfont.LOG_LOAD_FONTS_ = 'lf';
+tachyfont.LOG_LOAD_FONTS_ = 'LTFLF.';
 
 
 /** @private {string} */
-tachyfont.LOG_LOAD_FONTS_WAIT_PREVIOUS_ = 'lfw';
+tachyfont.LOG_LOAD_FONTS_WAIT_PREVIOUS_ = 'LTFLW.';
 
 
 /** @private {string} */
-tachyfont.LOG_SWITCH_FONT_ = 'sfe';
+tachyfont.LOG_SWITCH_FONT_ = 'LTFSE.';
 
 
 /** @private {string} */
-tachyfont.LOG_SWITCH_FONT_DELTA_TIME_ = 'sfe.d';
+tachyfont.LOG_SWITCH_FONT_DELTA_TIME_ = 'LTFSD.';
 
 
 /**
  * The reportError constants.
  */
 /** @private {string} */
-tachyfont.ERROR_FILE_ID_ = 'tf';
+tachyfont.ERROR_FILE_ID_ = 'ETF';
 
 
-/** @private {number} */
-tachyfont.ERROR_WINDOW_ON_ERROR_ = 1;
+/** @private {string} */
+tachyfont.ERROR_WINDOW_ON_ERROR_ = '01.';
 
 
-/** @private {number} */
-tachyfont.ERROR_SET_FONT_ = 2;
+/** @private {string} */
+tachyfont.ERROR_SET_FONT_ = '02.';
 
 
-/** @private {number} */
-tachyfont.ERROR_GET_BASE_ = 3;
+/** @private {string} */
+tachyfont.ERROR_GET_BASE_ = '03.';
 
 
 /**
  * The error reporter for this file.
  *
- * @param {number} errNum The error number;
- * @param {string} errId The error identifier;
+ * @param {string} errNum The error number;
  * @param {*} errInfo The error object;
  * @private
  */
-tachyfont.reportError_ = function(errNum, errId, errInfo) {
+tachyfont.reportError_ = function(errNum, errInfo) {
   if (tachyfont.reporter) {
-    tachyfont.reporter.reportError(tachyfont.ERROR_FILE_ID_ + errNum, errId,
+    tachyfont.reporter.reportError(tachyfont.ERROR_FILE_ID_ + errNum, '000',
         errInfo);
   } else {
     var obj = {};
     obj.errNum = errNum;
-    obj.errId = errId;
     obj.errInfo = errInfo;
     setTimeout(function() {
       tachyfont.delayedReportError_(obj);
@@ -310,7 +307,7 @@ tachyfont.reportError_ = function(errNum, errId, errInfo) {
  */
 tachyfont.delayedReportError_ = function(obj) {
   goog.log.error(tachyfont.logger, 'delayedReportError_');
-  tachyfont.reportError_(obj.errNum, obj.errId, obj.errInfo);
+  tachyfont.reportError_(obj.errNum, obj.errInfo);
 };
 
 
@@ -350,7 +347,7 @@ tachyfont.loadFonts = function(familyName, fontsInfo, opt_params) {
         (window.location.port ? ':' + window.location.port : '');
   }
   tachyfont.initializeReporter(url);
-  tachyfont.reporter.addItemTime(tachyfont.LOG_LOAD_FONTS_);
+  tachyfont.reporter.addItemTime(tachyfont.LOG_LOAD_FONTS_ + '000');
 
   // TODO(bstell): this initialization of TachyFontSet should be in the
   // constructor or and init function.
@@ -380,8 +377,8 @@ tachyfont.loadFonts = function(familyName, fontsInfo, opt_params) {
   // getChainedPromise. getChainedPromise should be waitForPrecedingPromise.
   allLoaded.getPrecedingPromise().
       then(function() {
-        tachyfont.reporter.addItem(tachyfont.LOG_LOAD_FONTS_WAIT_PREVIOUS_,
-          '000', goog.now() - waitPreviousTime);
+        tachyfont.reporter.addItem(tachyfont.LOG_LOAD_FONTS_WAIT_PREVIOUS_ +
+            '000', goog.now() - waitPreviousTime);
         if (goog.DEBUG) {
           goog.log.log(tachyfont.logger, goog.log.Level.FINER,
               'loadFonts: done waiting for preceding update');
@@ -441,7 +438,7 @@ tachyfont.loadFonts = function(familyName, fontsInfo, opt_params) {
                   // Report Set Font Early.
                   var weight = this.fontInfo.getWeight();
                   tachyfont.reporter.addItem(tachyfont.LOG_SWITCH_FONT_ +
-                    weight, goog.now() - incrFont.startTime_);
+                  weight, goog.now() - incrFont.startTime);
                   var deltaTime = goog.now() - this.sfeStart_;
                   tachyfont.reporter.addItem(
                       tachyfont.LOG_SWITCH_FONT_DELTA_TIME_ + weight,
@@ -467,11 +464,11 @@ tachyfont.loadFonts = function(familyName, fontsInfo, opt_params) {
             }).
             thenCatch(function(e) {
               allLoaded.reject();
-              tachyfont.reportError_(tachyfont.ERROR_SET_FONT_, '000', e);
+              tachyfont.reportError_(tachyfont.ERROR_SET_FONT_, e);
             });
       }).
       thenCatch(function(e) {
-        tachyfont.reportError_(tachyfont.ERROR_GET_BASE_, '000', e);
+        tachyfont.reportError_(tachyfont.ERROR_GET_BASE_, e);
         allLoaded.reject();
       });
 
@@ -570,30 +567,30 @@ tachyfont.loadFonts = function(familyName, fontsInfo, opt_params) {
 };
 
 
-///**
-// * Update a list of TachyFonts
-// *
-// * TODO(bstell): remove the tachyfont.TachyFont type.
-// * @param {Array.<tachyfont.TachyFont>|tachyfont.TachyFontSet} tachyFonts The
-// *     list of font objects.
-// */
-//tachyfont.updateFonts = function(tachyFonts) {
-//  if (tachyFonts.constructor == Array) {
-//    if (goog.DEBUG) {
-//      goog.log.info(tachyfont.logger,
-//          'tachyfont.updateFonts: passing in an array is deprecated');
-//    }
-//    for (var i = 0; i < tachyFonts.length; i++) {
-//      var tachyFont = tachyFonts[i];
-//      tachyFont.incrfont.loadChars();
-//    }
-//  } else if (tachyFonts.constructor == tachyfont.TachyFontSet) {
-//    if (goog.DEBUG) {
-//      goog.log.info(tachyfont.logger, 'tachyfont.updateFonts');
-//    }
-//    tachyFonts.updateFonts(true);
-//  }
-//};
+/**
+ * Update a list of TachyFonts
+ *
+ * TODO(bstell): remove the tachyfont.TachyFont type.
+ * @param {Array.<tachyfont.TachyFont>|tachyfont.TachyFontSet} tachyFonts The
+ *     list of font objects.
+ */
+tachyfont.updateFonts = function(tachyFonts) {
+  //  if (tachyFonts.constructor == Array) {
+  //    if (goog.DEBUG) {
+  //      goog.log.info(tachyfont.logger,
+  //          'tachyfont.updateFonts: passing in an array is deprecated');
+  //    }
+  //    for (var i = 0; i < tachyFonts.length; i++) {
+  //      var tachyFont = tachyFonts[i];
+  //      tachyFont.incrfont.loadChars();
+  //    }
+  //  } else if (tachyFonts.constructor == tachyfont.TachyFontSet) {
+  //    if (goog.DEBUG) {
+  //      goog.log.info(tachyfont.logger, 'tachyfont.updateFonts');
+  //    }
+  //    tachyFonts.updateFonts(true);
+  //  }
+};
 
 
 /**

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfontpromise.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfontpromise.js
@@ -64,34 +64,33 @@ tachyfont.promise = function(opt_container, opt_msg) {
  * The reportError constants.
  */
 /** @private {string} */
-tachyfont.promise.ERROR_FILE_ID_ = 'p';
+tachyfont.promise.ERROR_FILE_ID_ = 'ETP';
 
 
-/** @private {number} */
-tachyfont.promise.ERROR_PRECEDING_PROMISE_ = 1;
+/** @private {string} */
+tachyfont.promise.ERROR_PRECEDING_PROMISE_ = '01.';
 
 
-/** @private {number} */
-tachyfont.promise.ERROR_RESOLVE_CHAINED_COUNT_ = 2;
+/** @private {string} */
+tachyfont.promise.ERROR_RESOLVE_CHAINED_COUNT_ = '02.';
 
 
-/** @private {number} */
-tachyfont.promise.ERROR_REJECT_CHAINED_COUNT_ = 3;
+/** @private {string} */
+tachyfont.promise.ERROR_REJECT_CHAINED_COUNT_ = '03.';
 
 
-/** @private {number} */
-tachyfont.promise.ERROR_LINGERING_PROMISE_ = 4;
+/** @private {string} */
+tachyfont.promise.ERROR_LINGERING_PROMISE_ = '04.';
 
 
 /**
  * The error reporter for this file.
  *
- * @param {number} errNum The error number;
- * @param {string} errId Identifies the error.
+ * @param {string} errNum The error number;
  * @param {*} errInfo The error object;
  * @private
  */
-tachyfont.promise.reportError_ = function(errNum, errId, errInfo) {
+tachyfont.promise.reportError_ = function(errNum, errInfo) {
   if (goog.DEBUG) {
     if (!tachyfont.reporter) {
       debugger; // Failed to report error.
@@ -100,7 +99,7 @@ tachyfont.promise.reportError_ = function(errNum, errId, errInfo) {
   }
   if (tachyfont.reporter) {
     tachyfont.reporter.reportError(tachyfont.promise.ERROR_FILE_ID_ + errNum,
-        errId, errInfo);
+        '000', errInfo);
   }
 };
 
@@ -123,7 +122,7 @@ tachyfont.promise.prototype.getPromise = function() {
 tachyfont.promise.prototype.getPrecedingPromise = function() {
   if (!this.precedingPromise_) {
     tachyfont.promise.reportError_(tachyfont.promise.ERROR_PRECEDING_PROMISE_,
-        '000', this.msg_);
+        this.msg_);
   }
   return this.precedingPromise_;
 };
@@ -142,7 +141,7 @@ tachyfont.promise.prototype.reject = function(opt_value) {
       // We unshift all except the very first manually added promise.
       if (this.container_.chainedCount_ != 0) {
         tachyfont.promise.reportError_(
-            tachyfont.promise.ERROR_REJECT_CHAINED_COUNT_, '000', this.msg_);
+            tachyfont.promise.ERROR_REJECT_CHAINED_COUNT_, this.msg_);
       }
     }
     if (this.container_.promises.length > 1) {
@@ -169,7 +168,7 @@ tachyfont.promise.prototype.resolve = function(opt_value) {
       // We unshift all except the very first manually added promise.
       if (this.container_.chainedCount_ != 0) {
         tachyfont.promise.reportError_(
-            tachyfont.promise.ERROR_RESOLVE_CHAINED_COUNT_, '000', this.msg_);
+            tachyfont.promise.ERROR_RESOLVE_CHAINED_COUNT_, this.msg_);
       }
     }
     if (this.container_.promises.length > 1) {
@@ -228,7 +227,7 @@ tachyfont.chainedPromises = function() {
         this.timerReportCount_++;
         if (this.timerReportCount_ >= 10) {
           tachyfont.promise.reportError_(
-              tachyfont.promise.ERROR_LINGERING_PROMISE_, '000',
+              tachyfont.promise.ERROR_LINGERING_PROMISE_,
               this.debugMsg_ + 'gave up checking for pending count');
           clearInterval(this.intervalId_);
         }

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfontset.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfontset.js
@@ -118,41 +118,40 @@ tachyfont.TachyFontSet = function(familyName) {
  * The addItem constants.
  */
 /** @private {string} */
-tachyfont.TachyFontSet.LOG_SET_FONT_ = 'sf';
+tachyfont.TachyFontSet.LOG_SET_FONT_ = 'LTSSF.';
 
 
 /** @private {string} */
-tachyfont.TachyFontSet.LOG_SET_FONT_DELAYED_ = 'sfd';
+tachyfont.TachyFontSet.LOG_SET_FONT_DELAYED_ = 'LTSSD.';
 
 
 /** @private {string} */
-tachyfont.TachyFontSet.LOG_SET_FONT_DOM_LOADED_ = 'sfl';
+tachyfont.TachyFontSet.LOG_SET_FONT_DOM_LOADED_ = 'LTSSL.';
 
 
 /**
  * The reportError constants.
  */
 /** @private {string} */
-tachyfont.TachyFontSet.ERROR_FILE_ID_ = 'tfs';
+tachyfont.TachyFontSet.ERROR_FILE_ID_ = 'ETS';
 
 
-/** @private {number} */
-tachyfont.TachyFontSet.ERROR_UPDATE_FONT_LOAD_CHARS_ = 1;
+/** @private {string} */
+tachyfont.TachyFontSet.ERROR_UPDATE_FONT_LOAD_CHARS_ = '01.';
 
 
-/** @private {number} */
-tachyfont.TachyFontSet.ERROR_UPDATE_FONT_SET_FONT_ = 2;
+/** @private {string} */
+tachyfont.TachyFontSet.ERROR_UPDATE_FONT_SET_FONT_ = '02.';
 
 
 /**
  * The error reporter for this file.
  *
- * @param {number} errNum The error number;
- * @param {string} errId Error identifer.
+ * @param {string} errNum The error number;
  * @param {*} errObj The error object;
  * @private
  */
-tachyfont.TachyFontSet.reportError_ = function(errNum, errId, errObj) {
+tachyfont.TachyFontSet.reportError_ = function(errNum, errObj) {
   if (goog.DEBUG) {
     if (!tachyfont.reporter) {
       debugger; // Failed to report the error.
@@ -161,7 +160,7 @@ tachyfont.TachyFontSet.reportError_ = function(errNum, errId, errObj) {
   }
   if (tachyfont.reporter) {
     tachyfont.reporter.reportError(
-        tachyfont.TachyFontSet.ERROR_FILE_ID_ + errNum, errId, errObj);
+        tachyfont.TachyFontSet.ERROR_FILE_ID_ + errNum, '000', errObj);
   }
 };
 
@@ -397,7 +396,7 @@ tachyfont.TachyFontSet.prototype.addTextToFontGroups = function(node) {
 
 /**
  * Request an update of a group of TachyFonts.
- * 
+ *
  * @param {number} startTime The time when the chars were added to the DOM.
  */
 tachyfont.TachyFontSet.prototype.requestUpdateFonts = function(startTime) {
@@ -436,7 +435,7 @@ tachyfont.TachyFontSet.prototype.requestUpdateFonts = function(startTime) {
  *
  */
 tachyfont.TachyFontSet.prototype.updateFonts =
-     function(startTime, allowEarlyUse) {
+    function(startTime, allowEarlyUse) {
   this.lastRequestUpdateTime_ = goog.now();
   if (goog.DEBUG) {
     goog.log.fine(tachyfont.logger, 'updateFonts');
@@ -472,7 +471,7 @@ tachyfont.TachyFontSet.prototype.updateFonts =
       }.bind(this)).
       thenCatch(function(err) {
         tachyfont.TachyFontSet.reportError_(
-            tachyfont.TachyFontSet.ERROR_UPDATE_FONT_LOAD_CHARS_, '000', err);
+            tachyfont.TachyFontSet.ERROR_UPDATE_FONT_LOAD_CHARS_, err);
       }).
       then(function(/*loadResults*/) {
         var fontsData = [];
@@ -526,19 +525,18 @@ tachyfont.TachyFontSet.prototype.updateFonts =
               then(function() {
                 if (startTime == 0) {
                   tachyfont.reporter.addItemTime(
-                    tachyfont.TachyFontSet.LOG_SET_DOM_LOADED_ +
-                    this.fontInfo.getWeight());
-                  
+                  tachyfont.TachyFontSet.LOG_SET_FONT_DOM_LOADED_ +
+                  this.fontInfo.getWeight());
                 } else if (startTime >= 0) {
                   tachyfont.reporter.addItem(
-                    tachyfont.TachyFontSet.LOG_SET_FONT_ +
-                    this.fontInfo.getWeight(),
-                    goog.now() - startTime);
+                  tachyfont.TachyFontSet.LOG_SET_FONT_ +
+                  this.fontInfo.getWeight(),
+                  goog.now() - startTime);
                 } else {
                   tachyfont.reporter.addItem(
-                    tachyfont.TachyFontSet.LOG_SET_FONT_DELAYED_ +
-                    this.fontInfo.getWeight(),
-                    goog.now() + startTime);
+                  tachyfont.TachyFontSet.LOG_SET_FONT_DELAYED_ +
+                  this.fontInfo.getWeight(),
+                  goog.now() + startTime);
                 }
                 tachyfont.IncrementalFontUtils.setVisibility(this.style,
                 this.fontInfo, true);
@@ -558,7 +556,7 @@ tachyfont.TachyFontSet.prototype.updateFonts =
       }.bind(this)).
       thenCatch(function(e) {
         tachyfont.TachyFontSet.reportError_(
-            tachyfont.TachyFontSet.ERROR_UPDATE_FONT_SET_FONT_, '000',
+            tachyfont.TachyFontSet.ERROR_UPDATE_FONT_SET_FONT_,
             'failed to load all fonts' + e.stack);
         allUpdated.reject();
       });


### PR DESCRIPTION
- Put the type at the beginning.
- Use uppercase as the individual characters are more distinct.