### PR TITLE
Wrap ttLib cmap code that constructs format 12/13 tables.

### DIFF
--- a/build_time/src/cleanup.py
+++ b/build_time/src/cleanup.py
@@ -16,7 +16,7 @@
 
 from cleaner import Cleaner
 from fontTools.ttLib.tables import _c_m_a_p
-from fontTools_wrapper_funcs import change_method, _cmap_format_4_compile
+from fontTools_wrapper_funcs import change_method, _cmap_format_4_compile, _cmap_format_12_or_13_compile
 from glyph_sets import get_whitespace_and_ignorable_list
 
 
@@ -28,8 +28,10 @@ def clean_invalid_glyphs_and_remove_hinting(fontfile, hinting, output, verbose):
   # subset of format 12.
   # do we still what this?
   change_method(_c_m_a_p.cmap_format_4,_cmap_format_4_compile, 'compile')
+  old_12_or_13_compile = change_method(_c_m_a_p.cmap_format_12_or_13, _cmap_format_12_or_13_compile, 'compile')
   cleaner.save(output)
   cleaner.close()
+  change_method(_c_m_a_p.cmap_format_12_or_13, old_12_or_13_compile, 'compile')
 
 
 def cleanup(fontfile, hinting, output, verbose):

--- a/build_time/src/fontTools_wrapper_funcs.py
+++ b/build_time/src/fontTools_wrapper_funcs.py
@@ -15,6 +15,7 @@
 """
 from fontTools.ttLib import getSearchRange
 from fontTools.ttLib.tables import _c_m_a_p
+from fontTools.misc.py23 import bytesjoin
 import array
 import operator
 import struct
@@ -314,3 +315,49 @@ def _cmap_format_4_compile(self, ttFont):
   return header + data
   
 
+def _cmap_format_12_or_13_compile(self, ttFont):
+  if self.data:
+    return struct.pack(">HHLLL", self.format, self.reserved, self.length, self.language, self.nGroups) + self.data
+  charCodes = list(self.cmap.keys())
+  lenCharCodes = len(charCodes)
+  names = list(self.cmap.values())
+  nameMap = ttFont.getReverseGlyphMap()
+  try:
+    gids = list(map(operator.getitem, [nameMap]*lenCharCodes, names))
+  except KeyError:
+    nameMap = ttFont.getReverseGlyphMap(rebuild=True)
+    try:
+      gids = list(map(operator.getitem, [nameMap]*lenCharCodes, names))
+    except KeyError:
+      # allow virtual GIDs in format 12 tables
+      gids = []
+      for name in names:
+        try:
+          gid = nameMap[name]
+        except KeyError:
+          try:
+            if (name[:3] == 'gid'):
+              gid = eval(name[3:])
+            else:
+              gid = ttFont.getGlyphID(name)
+          except:
+            raise KeyError(name)
+
+        gids.append(gid)
+
+  cmap = {}  # code:glyphID mapping
+  list(map(operator.setitem, [cmap]*len(charCodes), charCodes, gids))
+
+  charCodes.sort()
+  nGroups = 0
+  dataList =  []
+  maxIndex = len(charCodes)
+  for index in range(maxIndex):
+    charCode = charCodes[index]
+    glyphID = cmap[charCode]
+    dataList.append(struct.pack(">LLL", charCode, charCode, glyphID))
+    nGroups = nGroups + 1
+  data = bytesjoin(dataList)
+  lengthSubtable = len(data) +16
+  assert len(data) == (nGroups*12) == (lengthSubtable-16)
+  return struct.pack(">HHLLL", self.format, self.reserved , lengthSubtable, self.language, nGroups) + data


### PR DESCRIPTION
Currently some code in the _c_m_a_p file of the copy of ttLib under gae_server
is commented out / changed to avoid coalescing cmap runs.  In order to use
the upstream ttLib, the quick thing to do is handle this like the other ttLib
patches.

The only call that relies on this in the build_time is in cleanup.py.

This does not revert the original corresponding patch to _c_m_a_p
since I do not know if there's any runtime code that relies on it.  That
patch also changed an additional function, which this change does not
reimplement since it is not called from the build time code.