### PR TITLE
Work in progress: coding the char data response code.

### DIFF
--- a/run_time/src/gae_java/TachyFont/src/com/github/googlei18n/tachyfont/GetCharData.java
+++ b/run_time/src/gae_java/TachyFont/src/com/github/googlei18n/tachyfont/GetCharData.java
@@ -5,12 +5,13 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
+import java.util.TreeMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
@@ -20,33 +21,44 @@ import javax.servlet.http.*;
 public class GetCharData extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-    resp.setContentType("text/plain");
     // Get the codepoints.
-    String jarFilename = "fonts/noto/sans/NotoSansJP-Thin_subset_smp.TachyFont.jar";
+    // Pretend data for these chars was requested.
+    String[] requestedChars = { "\uD83C\uDE15", "a", "b", "c", "\"",  "\u2014", };
+
+    // Get the preprocessed font.
+    String jarFilename = "fonts/noto/sans/NotoSansJP-Thin.TachyFont.jar";
     JarFile jarFile = new JarFile("WEB-INF/" + jarFilename);
+    
+    // Get the cmap info.
     Map<Integer, Integer> cmapMap = getCmapMap(jarFile);
-    Iterator<Entry<Integer, Integer>> cmapIterator = cmapMap.entrySet().iterator();
-    resp.getWriter().println("code to gid:");
-    while (cmapIterator.hasNext()) {
-      Entry<Integer, Integer> pair = cmapIterator.next();
-      resp.getWriter().println("  " + pair.getKey() + " = " + pair.getValue());
-    }
 
+    // Get the closure info.
     Map<Integer, Set<Integer>> closureMap = getClosureMap(jarFile);
-    Iterator<Entry<Integer, Set<Integer>>> closureMapIterator =
-        closureMap.entrySet().iterator();
-    resp.getWriter().println("gid to closure:");
-    while (closureMapIterator.hasNext()) {
-      Entry<Integer, Set<Integer>> pair = closureMapIterator.next();
-      // TODO(bstell): this is not yet debugged.
-      resp.getWriter().println(pair.getKey() + " = " + pair.getValue());
-    }
 
-    // TODO(bstell): look in the closure file for other gids to include.
-    for (Integer value : cmapMap.values()) {
-      System.out.println("look for the closure of gid = " + value);
+    // Determine the glyphs including the closure glyphs.
+    Set<Integer> requestedGids = new TreeSet<Integer>();
+    for (String requestedChar : requestedChars) {
+      int codePoint = requestedChar.codePointAt(0);
+      Integer gid = cmapMap.get(codePoint);
+      requestedGids.add(gid);
+      Set<Integer> closureGids = closureMap.get(gid);
+      if (closureGids != null) {
+        // TODO(bstell: check if the closure covered other chars.
+        requestedGids.addAll(closureGids);
+      }
     }
-    // TODO(bstell): create and return the glyph bundle.
+    System.out.println("requested chars: " + Arrays.toString(requestedChars));
+    System.out.println("gids: " + requestedGids);
+
+    // TODO(bstell): get the glyph info.
+    byte[] glyphInfo = getGlyphBundle(jarFile, requestedGids);
+
+    // TODO(bstell): create the glyph bundle.
+
+    // For development: send something to the display.
+    resp.setContentType("text/plain");
+    resp.getWriter().println("requested chars: " + Arrays.toString(requestedChars));
+    resp.getWriter().println("gids: " + requestedGids);
     jarFile.close();
   }
 
@@ -59,7 +71,7 @@ public class GetCharData extends HttpServlet {
     InputStream gidsStream = jarFile.getInputStream(gidsJarEntry);
     DataInputStream gidsDataStream = new DataInputStream(gidsStream);
 
-    HashMap<Integer, Integer> cmapMap = new HashMap<Integer, Integer>();
+    Map<Integer, Integer> cmapMap = new TreeMap<Integer, Integer>();
     while (codePointsDataStream.available() > 0) {
       Integer codePoint = codePointsDataStream.readInt();
       Integer gid = gidsDataStream.readUnsignedShort();
@@ -70,43 +82,94 @@ public class GetCharData extends HttpServlet {
 
   private Map<Integer, Set<Integer>> getClosureMap(JarFile jarFile) throws IOException {
     JarEntry closureIndexJarEntry = jarFile.getJarEntry("closure_idx");
-    InputStream closureIndexStream = jarFile.getInputStream(closureIndexJarEntry);
-    DataInputStream closureIndexDataStream = new DataInputStream(closureIndexStream);
+    InputStream index = jarFile.getInputStream(closureIndexJarEntry);
+    DataInputStream indexInput = new DataInputStream(index);
 
     JarEntry closureDataJarEntry = jarFile.getJarEntry("closure_data");
     InputStream closureDataStream = jarFile.getInputStream(closureDataJarEntry);
-    int closureDataSize = closureDataStream.available();
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    byte[] buffer = new byte[closureDataSize];
-    int readLength;
-    while ((readLength = closureDataStream.read(buffer, 0, closureDataSize)) != -1)
-      byteArrayOutputStream.write(buffer, 0, readLength);
-    buffer = byteArrayOutputStream.toByteArray();
-
-    ByteArrayInputStream closureDataByteArrayInputStream =
-        new ByteArrayInputStream(buffer);
-    DataInputStream closureDataInputStream =
-        new DataInputStream(closureDataByteArrayInputStream);
-    HashMap<Integer, Set<Integer>> closureMap = new HashMap<Integer, Set<Integer>>();
-    Integer gid = -1;
-    while (closureIndexDataStream.available() > 0) {
+    DataInputStream dataInput = new DataInputStream(closureDataStream);
+    Map<Integer, Set<Integer>> closureMap = new TreeMap<Integer, Set<Integer>>();
+    int gid = -1;
+    while (indexInput.available() > 0) {
       gid++;
-      Integer offset = closureIndexDataStream.readInt();
-      Integer size = closureIndexDataStream.readUnsignedShort();
+      Integer offset = indexInput.readInt();
+      Integer size = indexInput.readUnsignedShort();
       if (size == 0) {
         continue;
       }
-      // TODO(bstell): the following is not yet debugged.
-      Set<Integer> closureGids = new HashSet<Integer>();
-      closureDataByteArrayInputStream.reset();
-      closureDataByteArrayInputStream.skip(offset);
-      while (size > 0) {
-        Integer closureGid = closureDataInputStream.readUnsignedShort();
-        closureGids.add(closureGid);
-        size -= 2;
+      if (size < 0) {
+        System.out.printf("gid %d: size = %d\n", gid, size);
+        continue;
       }
-      closureMap.put(gid, closureGids);
+      Set<Integer> closureGids = new TreeSet<Integer>();
+      while (size > 0) {
+        int closureGid = dataInput.readUnsignedShort();
+        size -= 2;
+        if (closureGid != gid) {
+          closureGids.add(closureGid);
+        }
+      }
+      if (!closureGids.isEmpty()) {
+        closureMap.put(gid, closureGids);
+      }
     }
     return closureMap;
+  }
+
+  private byte[] getGlyphBundle(JarFile jarFile, Set<Integer> gids) throws IOException {
+    byte[] bundle = new byte[1024]; // TODO(bstell): fix this. Maybe a ByteArrayOutputStream
+    JarEntry glyphInfoJarEntry = jarFile.getJarEntry("glyph_table");
+    InputStream glyphInfoStream = jarFile.getInputStream(glyphInfoJarEntry);
+    int leng = glyphInfoStream.available();
+    DataInputStream glyphInfoInput = new DataInputStream(glyphInfoStream);
+    int flags = glyphInfoInput.readUnsignedShort();
+    int numberGlyphs = glyphInfoInput.readUnsignedShort();
+    int hmtxBit = (1 << 0);
+    int vmtxBit = (1 << 1);
+    int cffBit = (1 << 2);
+    boolean hasHmtx = (flags & hmtxBit) != 0;
+    boolean hasVmtx = (flags & vmtxBit) != 0;
+    boolean hasCff = (flags & cffBit) != 0;
+    List<Integer> glyphInfo = new ArrayList();
+    for (int i = 0; i < numberGlyphs; i++) {
+      int something1 = glyphInfoInput.readUnsignedShort();
+      Integer something2 = hasHmtx ? (int)glyphInfoInput.readShort() : null;
+      Integer something3 = hasVmtx ? (int)glyphInfoInput.readShort() : null;
+      int something4 = (int) glyphInfoInput.readInt();
+      int something5 = glyphInfoInput.readUnsignedShort();
+      int dummy = 3;
+    }
+    
+    
+
+    JarEntry glyphDataJarEntry = jarFile.getJarEntry("glyph_data");
+    InputStream glyphDataStream = jarFile.getInputStream(glyphDataJarEntry);
+    DataInputStream dataInput = new DataInputStream(glyphDataStream);
+//    Map<Integer, Set<Integer>> closureMap = new TreeMap<Integer, Set<Integer>>();
+//    Integer gid = -1;
+//    while (indexInput.available() > 0) {
+//      gid++;
+//      Integer offset = indexInput.readInt();
+//      Integer size = indexInput.readUnsignedShort();
+//      if (size == 0) {
+//        continue;
+//      }
+//      if (size < 0) {
+//        System.out.printf("gid %d: size = %d\n", gid, size);
+//        continue;
+//      }
+//      Set<Integer> closureGids = new TreeSet<Integer>();
+//      while (size > 0) {
+//        Integer closureGid = dataInput.readUnsignedShort();
+//        size -= 2;
+//        if (closureGid.intValue() != gid.intValue()) {
+//          closureGids.add(closureGid);
+//        }
+//      }
+//      if (!closureGids.isEmpty()) {
+//        closureMap.put(gid, closureGids);
+//      }
+//    }
+    return bundle;
   }
 }


### PR DESCRIPTION
Switch to a font with closure data.
Make up a set of requested chars including a surrogate and a char with
multiple closure glyphs.
Remove some of the read-cmap development code.
Add code to read the glyph closure info.
Starting to create the glyph bundle.
Convert input/output parameters to more generic types.
Change the HashMap objects to TreeMap to get sorting.
Now that the gids are sorted: when parsing the closure data get rid of
the ByteArrayOutputStream.