### PR TITLE
add a priority flag to the font so it can be handle before the non-priority fonts.

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/fontinfo.js
+++ b/run_time/src/gae_server/www/js/tachyfont/fontinfo.js
@@ -24,21 +24,21 @@ goog.provide('tachyfont.FontInfo');
 /**
  * The information for a font.
  *
- * @param {string} name The font name.
- * @param {string} weight The font weight.
- * @param {string=} opt_familyPath The font family path.
- * @param {string=} opt_version The font version.
- * @param {string=} opt_fontKit The font kit.
+ * @param {?string} name The font name.
+ * @param {?string} weight The font weight.
+ * @param {?string=} opt_familyPath The font family path.
+ * @param {?string=} opt_version The font version.
+ * @param {?string=} opt_fontKit The font kit.
  * @constructor
  */
 tachyfont.FontInfo =
     function(name, weight, opt_familyPath, opt_version, opt_fontKit) {
 
   /** @private {string} */
-  this.name_ = name;
+  this.name_ = name || '';
 
   /** @private {string} */
-  this.weight_ = weight;
+  this.weight_ = weight || '';
 
   /** @private {string} */
   this.familyPath_ = opt_familyPath || '';
@@ -54,6 +54,9 @@ tachyfont.FontInfo =
 
   /** @private {string} */
   this.dataUrl_ = '';
+
+  /** @private {boolean} */
+  this.priority_ = false;
 };
 
 
@@ -82,7 +85,7 @@ tachyfont.FontInfo.prototype.getWeight = function() {
  *
  * @return {string|undefined} The font directory of the TachyFont.
  */
-tachyfont.FontInfo.prototype.getfamilyPath = function() {
+tachyfont.FontInfo.prototype.getFamilyPath = function() {
   return this.familyPath_;
 };
 
@@ -147,14 +150,34 @@ tachyfont.FontInfo.prototype.setDataUrl = function(dataUrl) {
 };
 
 
+/**
+ * Get the priority of this font.
+ *
+ * @return {boolean} True if is a priority font.
+ */
+tachyfont.FontInfo.prototype.getPriority = function() {
+  return this.priority_;
+};
+
+
+/**
+ * Set the priority of this font.
+ *
+ * @param {?boolean} priority True if is a priority font.
+ */
+tachyfont.FontInfo.prototype.setPriority = function(priority) {
+  this.priority_ = priority ? true : false;
+};
+
+
 goog.scope(function() {
 goog.exportSymbol('tachyfont.FontInfo', tachyfont.FontInfo);
 goog.exportProperty(tachyfont.FontInfo.prototype, 'getName',
                     tachyfont.FontInfo.prototype.getName);
 goog.exportProperty(tachyfont.FontInfo.prototype, 'getWeight',
                     tachyfont.FontInfo.prototype.getWeight);
-goog.exportProperty(tachyfont.FontInfo.prototype, 'getfamilyPath',
-                    tachyfont.FontInfo.prototype.getfamilyPath);
+goog.exportProperty(tachyfont.FontInfo.prototype, 'getFamilyPath',
+                    tachyfont.FontInfo.prototype.getFamilyPath);
 goog.exportProperty(tachyfont.FontInfo.prototype, 'getVersion',
                     tachyfont.FontInfo.prototype.getVersion);
 goog.exportProperty(tachyfont.FontInfo.prototype, 'getFontKit',
@@ -167,5 +190,9 @@ goog.exportProperty(tachyfont.FontInfo.prototype, 'getDataUrl',
                     tachyfont.FontInfo.prototype.getDataUrl);
 goog.exportProperty(tachyfont.FontInfo.prototype, 'setDataUrl',
                     tachyfont.FontInfo.prototype.setDataUrl);
+goog.exportProperty(tachyfont.FontInfo.prototype, 'getPriority',
+                    tachyfont.FontInfo.prototype.getPriority);
+goog.exportProperty(tachyfont.FontInfo.prototype, 'setPriority',
+                    tachyfont.FontInfo.prototype.setPriority);
 });  // goog.scope
 

--- a/run_time/src/gae_server/www/js/tachyfont/googlebackendservice.js
+++ b/run_time/src/gae_server/www/js/tachyfont/googlebackendservice.js
@@ -105,7 +105,7 @@ GoogleBackendService.prototype.log = function(message) {
  */
 GoogleBackendService.prototype.getDataUrl_ =
     function(fontInfo, prefix, suffix) {
-  var familyPath = fontInfo.getfamilyPath();
+  var familyPath = fontInfo.getFamilyPath();
   if (!familyPath) {
     // Using familyPath is preferred over familyName.
     familyPath = fontInfo.getFamilyName().replace(/ /g, '').toLowerCase();


### PR DESCRIPTION
Rename getfamilyPath to getFamilyPath.
Slight tuning of JsDoc parameters.