### PR TITLE
add a priority flag to the font so it can be handle before the non-priority fonts.

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/fontsinfo.js
+++ b/run_time/src/gae_server/www/js/tachyfont/fontsinfo.js
@@ -27,8 +27,8 @@ goog.require('tachyfont.FontInfo');
  * The information for a set of fonts.
  *
  * @param {!Array.<tachyfont.FontInfo>} fonts .
- * @param {string} dataUrl The URL of the Tachyfont server.
- * @param {string} reportUrl The URL to send logging/error reports to.
+ * @param {?string} dataUrl The URL of the Tachyfont server.
+ * @param {?string} reportUrl The URL to send logging/error reports to.
  * @constructor
  */
 tachyfont.FontsInfo = function(fonts, dataUrl, reportUrl) {
@@ -36,10 +36,10 @@ tachyfont.FontsInfo = function(fonts, dataUrl, reportUrl) {
   this.fonts_ = fonts;
 
   /** @private {string} */
-  this.dataUrl_ = dataUrl;
+  this.dataUrl_ = dataUrl || '';
 
   /** @private {string} */
-  this.reportUrl_ = reportUrl;
+  this.reportUrl_ = reportUrl || '';
 };
 
 


### PR DESCRIPTION
Rename getfamilyPath to getFamilyPath.
Slight tuning of JsDoc parameters.