### PR TITLE
Remove the circular dependency of tachyfont.logger.

### DIFF
--- a/run_time/src/gae_server/www/js/closure_deps.js
+++ b/run_time/src/gae_server/www/js/closure_deps.js
@@ -23,13 +23,15 @@ goog.addDependency('../../../tachyfont/binaryfonteditor.js',
     []);
 goog.addDependency('../../../tachyfont/browser_chrome.js',
     ['tachyfont.Browser'],
-    ['goog.Promise']);
+    ['goog.Promise', 'goog.log', 'goog.log.Level',
+     'tachyfont.IncrementalFontUtils', 'tachyfont.Logger']);
 goog.addDependency('../../../tachyfont/charcmapinfo.js',
     ['tachyfont.CharCmapInfo'],
     []);
 goog.addDependency('../../../tachyfont/cmap.js',
     ['tachyfont.Cmap'],
-    ['goog.log', 'goog.log.Level', 'tachyfont.BinaryFontEditor']);
+    ['goog.log', 'goog.log.Level', 'tachyfont.BinaryFontEditor',
+     'tachyfont.Logger']);
 goog.addDependency('../../../tachyfont/demobackendservice.js',
     ['tachyfont.DemoBackendService'],
     ['goog.events', 'goog.net.EventType', 'goog.net.XhrIo',
@@ -50,49 +52,48 @@ goog.addDependency('../../../tachyfont/googlebackendservice.js',
 goog.addDependency('../../../tachyfont/incrementalfont.js',
     ['tachyfont.IncrementalFont'],
     ['goog.Promise', 'goog.log', 'goog.log.Level', 'goog.math',
-     'tachyfont.BinaryFontEditor', 'tachyfont.Browser',
-     'tachyfont.CharCmapInfo', 'tachyfont.Cmap',
-     'tachyfont.DemoBackendService', 'tachyfont.FontInfo',
-     'tachyfont.GoogleBackendService', 'tachyfont.IncrementalFontUtils',
-     'tachyfont.Persist', 'tachyfont.RLEDecoder', 'tachyfont.chainedPromises',
-     'tachyfont.promise', 'tachyfont.utils']);
+     'tachyfont.BinaryFontEditor', 'tachyfont.Browser', 'tachyfont.Cmap',
+     'tachyfont.DemoBackendService', 'tachyfont.GoogleBackendService',
+     'tachyfont.IncrementalFontUtils', 'tachyfont.Logger', 'tachyfont.Persist',
+     'tachyfont.RLEDecoder', 'tachyfont.chainedPromises', 'tachyfont.promise',
+     'tachyfont.utils']);
 goog.addDependency('../../../tachyfont/incrementalfontutils.js',
     ['tachyfont.IncrementalFontUtils'],
-    ['goog.asserts', 'goog.log', 'tachyfont.BinaryFontEditor',
-     'tachyfont.CharCmapInfo', 'tachyfont.FontInfo']);
-goog.addDependency('../../../misc_utils.js',
-    ['tachyfont_misc_utils'],
-    []);
+    ['goog.asserts', 'goog.log', 'goog.log.Level', 'tachyfont.BinaryFontEditor',
+     'tachyfont.CharCmapInfo', 'tachyfont.FontInfo', 'tachyfont.Logger']);
 goog.addDependency('../../../tachyfont/persist_idb.js',
     ['tachyfont.Persist'],
-    ['goog.Promise']);
+    ['goog.Promise', 'goog.log', 'tachyfont.Logger']);
 goog.addDependency('../../../tachyfont/rledecoder.js',
-    ['tachyfont.RLEDecoder'],
-    []);
+  ['tachyfont.RLEDecoder'],
+  []);
 goog.addDependency('../../../tachyfont/tachyfont.js',
     ['tachyfont', 'tachyfont.IncrementalFontLoader', 'tachyfont.TachyFont',
      'tachyfont.uint8',],
     ['goog.Promise', 'goog.Uri', 'goog.debug.Console', 'goog.debug.Logger',
-     'goog.log', 'goog.log.Level', 'tachyfont.BinaryFontEditor',
-     'tachyfont.FontInfo', 'tachyfont.FontsInfo',
+     'goog.log', 'goog.log.Level', 'tachyfont.FontsInfo', 'tachyfont.FontsInfo',
      'tachyfont.IncrementalFont', 'tachyfont.IncrementalFontUtils',
-     'tachyfont.Reporter', 'tachyfont.TachyFontSet']);
+     'tachyfont.Logger', 'tachyfont.Reporter', 'tachyfont.TachyFontSet']);
+goog.addDependency('../../../tachyfont/tachyfontlogger.js',
+    [ 'tachyfont.Logger'],
+    ['goog.log']);
 goog.addDependency('../../../tachyfont/tachyfontpromise.js',
     [ 'tachyfont.chainedPromises', 'tachyfont.promise'],
-    ['goog.Promise']);
+    ['goog.Promise', 'goog.log', 'goog.log.Level', 'tachyfont.Logger']);
 goog.addDependency('../../../tachyfont/tachyfontreporter.js',
     ['tachyfont.Reporter'],
-    ['goog.log']);
+    ['goog.log', 'tachyfont.Logger']);
 goog.addDependency('../../../tachyfont/tachyfontset.js',
     ['tachyfont.TachyFontSet'],
-    ['goog.Promise', 'goog.array', 'goog.log', 'goog.style',
-     'tachyfont.IncrementalFontUtils', 'tachyfont.chainedPromises']);
+    ['goog.Promise', 'goog.array', 'goog.log', 'goog.log.Level', 'goog.style',
+     'tachyfont.IncrementalFontUtils', 'tachyfont.Logger',
+     'tachyfont.chainedPromises']);
 goog.addDependency('../../../tachyfont/tachyfontutils.js',
     ['tachyfont.utils'],
     []);
-goog.addDependency('../../../tachyfont/webfonttailor.js',
-    ['webfonttailor'],
-    ['tachyfont.FontInfo', 'tachyfont.FontsInfo', 'webfonttailor.alternate']);
 goog.addDependency('../../../tachyfont/webfonttailoralternate.js',
     ['webfonttailor.alternate'],
     ['tachyfont.FontInfo', 'tachyfont.FontsInfo']);
+goog.addDependency('../../../tachyfont/webfonttailor.js',
+    ['webfonttailor'],
+    ['tachyfont.FontInfo', 'tachyfont.FontsInfo', 'webfonttailor.alternate']);

--- a/run_time/src/gae_server/www/js/tachyfont/browser_chrome.js
+++ b/run_time/src/gae_server/www/js/tachyfont/browser_chrome.js
@@ -20,6 +20,10 @@
 goog.provide('tachyfont.Browser');
 
 goog.require('goog.Promise');
+goog.require('goog.log');
+goog.require('goog.log.Level');
+goog.require('tachyfont.IncrementalFontUtils');
+goog.require('tachyfont.Logger');
 
 
 /**
@@ -50,7 +54,7 @@ tachyfont.Browser.setFont = function(fontData, fontInfo, isTtf, oldBlobUrl) {
         return tachyfont.Browser.setFontNoFlash(fontInfo, format, blobUrl).
            then(function() {
              if (goog.DEBUG) {
-               goog.log.fine(tachyfont.logger, 'setFont: setFont done');
+               goog.log.fine(tachyfont.Logger.logger, 'setFont: setFont done');
              }
              return goog.Promise.resolve(blobUrl);
            });
@@ -86,13 +90,12 @@ tachyfont.Browser.setFontNoFlash = function(fontInfo, format, blobUrl) {
   // The temporary @font-face font-family.
   var weight = fontInfo.getWeight();
   var tmpFontFamily = 'tmp-' + weight + '-' + fontFamily;
-  var fontName = fontInfo.getName(); // The font name.
   var sheet = tachyfont.IncrementalFontUtils.getStyleSheet();
 
   // Create a temporary @font-face rule to transfer the blobUrl data from
   // Javascript to the browser side.
   if (goog.DEBUG) {
-    goog.log.log(tachyfont.logger, goog.log.Level.FINER,
+    goog.log.log(tachyfont.Logger.logger, goog.log.Level.FINER,
         'setFont: ' + tmpFontFamily + '/' + weight);
   }
   tachyfont.IncrementalFontUtils.setCssFontRule(sheet, tmpFontFamily, weight,
@@ -103,7 +106,7 @@ tachyfont.Browser.setFontNoFlash = function(fontInfo, format, blobUrl) {
     // of 100. So use an artifical weight to work around this problem.
     var fontStr = '400 20px ' + tmpFontFamily;
     if (goog.DEBUG) {
-      goog.log.log(tachyfont.logger, goog.log.Level.FINER,
+      goog.log.log(tachyfont.Logger.logger, goog.log.Level.FINER,
           'setFont: fontStr = ' + fontStr);
     }
     // Transfer the data.
@@ -111,8 +114,8 @@ tachyfont.Browser.setFontNoFlash = function(fontInfo, format, blobUrl) {
     document.fonts.load(fontStr).
         then(function(value) {
           if (goog.DEBUG) {
-            goog.log.fine(tachyfont.logger, 'loaded ' + tmpFontFamily + '/' +
-                weight);
+            goog.log.fine(tachyfont.Logger.logger, 'loaded ' + tmpFontFamily +
+                '/' + weight);
           }
           resolve();
         });
@@ -141,7 +144,7 @@ tachyfont.Browser.setFontNoFlash = function(fontInfo, format, blobUrl) {
 tachyfont.Browser.switchFont = function(sheet, tmpFontFamily, fontFamily,
     weight, blobUrl, format) {
   if (goog.DEBUG) {
-    goog.log.log(tachyfont.logger, goog.log.Level.FINER,
+    goog.log.log(tachyfont.Logger.logger, goog.log.Level.FINER,
         'switch to fontFamily');
   }
   // Set the updated font rule.
@@ -152,7 +155,7 @@ tachyfont.Browser.switchFont = function(sheet, tmpFontFamily, fontFamily,
   var ruleToDelete = tachyfont.IncrementalFontUtils.findFontFaceRule(
       sheet, tmpFontFamily, weight);
   if (goog.DEBUG) {
-    goog.log.info(tachyfont.logger, '**** switched ' + weight +
+    goog.log.info(tachyfont.Logger.logger, '**** switched ' + weight +
         ' from ' + tmpFontFamily + ' to ' + fontFamily +
                 ' ****');
   }

--- a/run_time/src/gae_server/www/js/tachyfont/cmap.js
+++ b/run_time/src/gae_server/www/js/tachyfont/cmap.js
@@ -22,6 +22,7 @@ goog.provide('tachyfont.Cmap');
 goog.require('goog.log');
 goog.require('goog.log.Level');
 goog.require('tachyfont.BinaryFontEditor');
+goog.require('tachyfont.Logger');
 
 
 /**
@@ -68,7 +69,7 @@ tachyfont.Cmap.Error_ = {
 tachyfont.Cmap.reportError_ = function(errNum, errId, errInfo) {
   if (goog.DEBUG) {
     if (!tachyfont.reporter) {
-      goog.log.error(tachyfont.logger, 'failed to report error');
+      goog.log.error(tachyfont.Logger.logger, 'failed to report error');
     }
   }
   if (tachyfont.reporter) {
@@ -394,7 +395,7 @@ tachyfont.Cmap.setFormat4GlyphIds = function(fileInfo, baseFontView, glyphIds,
           ') != segments[' + i + '][1] (' + segments[i][2] + ')');
       if (goog.DEBUG) {
         if (segIdDelta == segments[i][2]) {
-          goog.log.info(tachyfont.logger, 'format 4 segment ' + i +
+          goog.log.info(tachyfont.Logger.logger, 'format 4 segment ' + i +
               ': segIdDelta already set');
         }
         return;
@@ -421,7 +422,7 @@ tachyfont.Cmap.setFormat4GlyphIds = function(fileInfo, baseFontView, glyphIds,
     for (var j = 0; j < codes.length; j++) {
       var code = codes[j];
       if (goog.DEBUG) {
-        goog.log.info(tachyfont.logger, 'format 4: code = ' + code);
+        goog.log.info(tachyfont.Logger.logger, 'format 4: code = ' + code);
       }
       var charCmapInfo = cmapMapping[code];
       if (!charCmapInfo) {
@@ -476,7 +477,7 @@ tachyfont.Cmap.setFormat12GlyphIds = function(fileInfo, baseFontView, glyphIds,
     for (var j = 0; j < codes.length; j++) {
       var code = codes[j];
       if (goog.DEBUG) {
-        goog.log.log(tachyfont.logger, goog.log.Level.FINER,
+        goog.log.log(tachyfont.Logger.logger, goog.log.Level.FINER,
             'format 12: code = ' + code);
       }
       var charCmapInfo = cmapMapping[code];

--- a/run_time/src/gae_server/www/js/tachyfont/incrementalfontutils.js
+++ b/run_time/src/gae_server/www/js/tachyfont/incrementalfontutils.js
@@ -21,9 +21,10 @@ goog.provide('tachyfont.IncrementalFontUtils');
 
 goog.require('goog.asserts');
 goog.require('goog.log');
+goog.require('goog.log.Level');
 goog.require('tachyfont.BinaryFontEditor');
 goog.require('tachyfont.CharCmapInfo');
-goog.require('tachyfont.FontInfo');
+goog.require('tachyfont.Logger');
 
 
 /**
@@ -248,7 +249,7 @@ tachyfont.IncrementalFontUtils.deleteCssRule = function(ruleToDelete, sheet) {
       sheet.removeRule(ruleToDelete);
     } else {
       if (goog.DEBUG) {
-        goog.log.error(tachyfont.logger, 'no delete/drop rule');
+        goog.log.error(tachyfont.Logger.logger, 'no delete/drop rule');
       }
     }
   }
@@ -273,7 +274,7 @@ tachyfont.IncrementalFontUtils.findFontFaceRule =
       var this_rule = rules[i];
       if (this_rule.type == CSSRule.FONT_FACE_RULE) {
         if (goog.DEBUG) {
-          goog.log.log(tachyfont.logger, goog.log.Level.FINER,
+          goog.log.log(tachyfont.Logger.logger, goog.log.Level.FINER,
               'found an @font-face rule');
         }
         var this_style = this_rule.style;
@@ -310,7 +311,8 @@ tachyfont.IncrementalFontUtils.setCssFontRule =
       ' format("' + format + '");\n' +
       '}\n';
   if (goog.DEBUG) {
-    goog.log.log(tachyfont.logger, goog.log.Level.FINER, 'rule = ' + rule_str);
+    goog.log.log(tachyfont.Logger.logger, goog.log.Level.FINER,
+        'rule = ' + rule_str);
   }
   var ruleToDelete = tachyfont.IncrementalFontUtils.findFontFaceRule(
       sheet, fontFamily, weight);

--- a/run_time/src/gae_server/www/js/tachyfont/persist_idb.js
+++ b/run_time/src/gae_server/www/js/tachyfont/persist_idb.js
@@ -20,6 +20,8 @@
 goog.provide('tachyfont.Persist');
 
 goog.require('goog.Promise');
+goog.require('goog.log');
+goog.require('tachyfont.Logger');
 
 
 /**
@@ -49,7 +51,7 @@ tachyfont.Persist.Error_ = {
 tachyfont.Persist.reportError_ = function(errNum, errId, errInfo) {
   if (goog.DEBUG) {
     if (!tachyfont.reporter) {
-      goog.log.error(tachyfont.logger, 'failed to report error');
+      goog.log.error(tachyfont.Logger.logger, 'failed to report error');
     }
   }
   if (tachyfont.reporter) {

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfontlogger.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfontlogger.js
@@ -1,0 +1,49 @@
+'use strict';
+
+/**
+ * @license
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+goog.provide('tachyfont.Logger');
+
+goog.require('goog.log');
+
+if (goog.DEBUG) {
+  /**
+   * A class variable to limit initialization to a single time.
+   *
+   * @private {boolean}
+   */
+  tachyfont.Logger.hasInitialized_ = false;
+
+  /**
+   * Initialize the logger.
+   * @param {goog.debug.Logger.Level} debugLevel The desired debug level.
+   */
+  tachyfont.Logger.init = function(debugLevel) {
+    if (tachyfont.Logger.hasInitialized_) {
+      throw new Error('logger already initialized');
+    }
+
+    tachyfont.Logger.hasInitialized_ = true;
+
+    /**
+     * @type {goog.debug.Logger}
+     */
+    tachyfont.Logger.logger = goog.log.getLogger('tachyfont', debugLevel);
+  };
+}
+

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfontpromise.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfontpromise.js
@@ -21,6 +21,9 @@ goog.provide('tachyfont.chainedPromises');
 goog.provide('tachyfont.promise');
 
 goog.require('goog.Promise');
+goog.require('goog.log');
+goog.require('goog.log.Level');
+goog.require('tachyfont.Logger');
 
 
 
@@ -43,9 +46,6 @@ tachyfont.promise = function(opt_container, opt_msg) {
     this.rejecter_ = reject;
     this.container_ = opt_container;
     this.msg_ = opt_msg;
-    if (opt_container) {
-      this.chainCount_ = opt_container.chainedCount_;
-    }
   }, this);
 
   /**
@@ -86,7 +86,7 @@ tachyfont.promise.reportError_ = function(errNum, errInfo) {
   if (goog.DEBUG) {
     if (!tachyfont.reporter) {
       debugger; // Failed to report error.
-      goog.log.error(tachyfont.logger, 'failed to report error');
+      goog.log.error(tachyfont.Logger.logger, 'failed to report error');
     }
   }
   if (tachyfont.reporter) {
@@ -140,7 +140,7 @@ tachyfont.promise.prototype.reject = function(opt_value) {
       this.container_.promises.shift();
       this.container_.pendingCount_--;
       if (goog.DEBUG) {
-        goog.log.log(tachyfont.logger, goog.log.Level.FINER,
+        goog.log.log(tachyfont.Logger.logger, goog.log.Level.FINER,
             this.msg_ + 'dropped count to ' + this.container_.pendingCount_);
       }
     }
@@ -167,7 +167,7 @@ tachyfont.promise.prototype.resolve = function(opt_value) {
       this.container_.promises.shift();
       this.container_.pendingCount_--;
       if (goog.DEBUG) {
-        goog.log.log(tachyfont.logger, goog.log.Level.FINER,
+        goog.log.log(tachyfont.Logger.logger, goog.log.Level.FINER,
             this.msg_ + 'dropped count to ' + this.container_.pendingCount_);
       }
     }
@@ -215,8 +215,8 @@ tachyfont.chainedPromises = function(msg) {
   this.intervalId_ = setInterval(function() {
     if (this.pendingCount_ != 0) {
       if (goog.DEBUG) {
-        goog.log.log(tachyfont.logger, goog.log.Level.WARNING, this.msg_ +
-            'lingering pending count: ' + this.pendingCount_);
+        goog.log.log(tachyfont.Logger.logger, goog.log.Level.WARNING,
+            this.msg_ + 'lingering pending count: ' + this.pendingCount_);
       }
       this.timerReportCount_++;
       if (this.timerReportCount_ >= 10) {
@@ -254,8 +254,8 @@ tachyfont.chainedPromises.prototype.getChainedPromise = function(msg) {
   this.chainedCount_++;
   this.pendingCount_++;
   if (goog.DEBUG) {
-    goog.log.log(tachyfont.logger, goog.log.Level.FINER, this.msg_ + msg +
-        ': increase pending count to ' + this.pendingCount_);
+    goog.log.log(tachyfont.Logger.logger, goog.log.Level.FINER,
+        this.msg_ + msg + ': increase pending count to ' + this.pendingCount_);
   }
   var precedingPromise = this.promises[this.promises.length - 1];
   var newPromise = new tachyfont.promise(this, msg);

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfontreporter.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfontreporter.js
@@ -20,6 +20,7 @@
 goog.provide('tachyfont.Reporter');
 
 goog.require('goog.log');
+goog.require('tachyfont.Logger');
 
 
 
@@ -36,15 +37,6 @@ tachyfont.Reporter = function(url) {
 
   /** @private {!Object.<string, (number|string)>} */
   this.items_ = {};
-
-  /**
-   * The duplicate items count;
-   *
-   * Useful when keeping duplicates separately.
-   *
-   * @private {!Object.<string, number>}
-   */
-  this.dupCnts_ = {};
 };
 
 
@@ -121,7 +113,6 @@ tachyfont.Reporter.prototype.reportError = function(errNum, id, errInfo) {
   var msg = '';
 
   // Get the error message out of the error object.
-  var value = '';
   if (typeof errInfo == 'string') {
     msg += errInfo;
   } else if (typeof errInfo == 'object') {
@@ -153,7 +144,7 @@ tachyfont.Reporter.prototype.reportError = function(errNum, id, errInfo) {
     keys.sort();
     for (var i = 0; i < keys.length; i++) {
       name = keys[i];
-      goog.log.error(tachyfont.logger, '    ' + name + ': ' +
+      goog.log.error(tachyfont.Logger.logger, '    ' + name + ': ' +
           this.items_[name]);
     }
     // debugger; // Enable this when debugging the reporter.
@@ -178,7 +169,7 @@ tachyfont.Reporter.prototype.sendReport = function(opt_okIfNoItems) {
   if (keys.length == 0) {
     if (goog.DEBUG) {
       if (!opt_okIfNoItems) {
-        goog.log.warning(tachyfont.logger, 'sendReport: no items');
+        goog.log.warning(tachyfont.Logger.logger, 'sendReport: no items');
       }
     }
     return;
@@ -188,7 +179,7 @@ tachyfont.Reporter.prototype.sendReport = function(opt_okIfNoItems) {
   var length = baseUrl.length;
   var items = [];
   if (goog.DEBUG) {
-    goog.log.info(tachyfont.logger, 'report items:');
+    goog.log.info(tachyfont.Logger.logger, 'report items:');
   }
   for (var i = 0; i < keys.length; i++) {
     var name = keys[i];
@@ -203,7 +194,7 @@ tachyfont.Reporter.prototype.sendReport = function(opt_okIfNoItems) {
     length += item.length;
     items.push(item);
     if (goog.DEBUG) {
-      goog.log.info(tachyfont.logger, '    ' + item);
+      goog.log.info(tachyfont.Logger.logger, '    ' + item);
     }
   }
   this.sendGen204_(baseUrl, items);


### PR DESCRIPTION
- tachyfont.js provides tachyfont.logger to the same files that it
goog.requires. 
- Move the logger to a separate class/file.

Add some missing goog.require statements.
Remove some unneeded goog.require statements.
Remove or comment out some unneeded variables.