### PR TITLE
Break the tachyfont.reporter circular dependency.

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/cmap.js
+++ b/run_time/src/gae_server/www/js/tachyfont/cmap.js
@@ -23,6 +23,7 @@ goog.require('goog.log');
 goog.require('goog.log.Level');
 goog.require('tachyfont.BinaryFontEditor');
 goog.require('tachyfont.Logger');
+goog.require('tachyfont.Reporter');
 
 
 /**
@@ -68,12 +69,12 @@ tachyfont.Cmap.Error_ = {
  */
 tachyfont.Cmap.reportError_ = function(errNum, errId, errInfo) {
   if (goog.DEBUG) {
-    if (!tachyfont.reporter) {
+    if (!tachyfont.Reporter.isReady()) {
       goog.log.error(tachyfont.Logger.logger, 'failed to report error');
     }
   }
-  if (tachyfont.reporter) {
-    tachyfont.reporter.reportError(
+  if (tachyfont.Reporter.isReady()) {
+    tachyfont.Reporter.reportError(
         tachyfont.Cmap.Error_.FILE_ID + errNum, errId, errInfo);
   }
 };

--- a/run_time/src/gae_server/www/js/tachyfont/persist_idb.js
+++ b/run_time/src/gae_server/www/js/tachyfont/persist_idb.js
@@ -22,6 +22,7 @@ goog.provide('tachyfont.Persist');
 goog.require('goog.Promise');
 goog.require('goog.log');
 goog.require('tachyfont.Logger');
+goog.require('tachyfont.Reporter');
 
 
 /**
@@ -50,12 +51,12 @@ tachyfont.Persist.Error_ = {
  */
 tachyfont.Persist.reportError_ = function(errNum, errId, errInfo) {
   if (goog.DEBUG) {
-    if (!tachyfont.reporter) {
+    if (!tachyfont.Reporter.isReady()) {
       goog.log.error(tachyfont.Logger.logger, 'failed to report error');
     }
   }
-  if (tachyfont.reporter) {
-    tachyfont.reporter.reportError(
+  if (tachyfont.Reporter.isReady()) {
+    tachyfont.Reporter.reportError(
         tachyfont.Persist.Error_.FILE_ID + errNum, errId, errInfo);
   }
 };

--- a/run_time/src/gae_server/www/js/tachyfont/sfnt.js
+++ b/run_time/src/gae_server/www/js/tachyfont/sfnt.js
@@ -36,7 +36,7 @@ tachyfont.Sfnt.TableOfContents = function() {
   /** @private {Array.<!tachyfont.Sfnt.TableOfContentsEntry>} */
   this.items_ = [];
 
-  /** @private {Object.<!string, !number>} */
+  /** @private {Object.<string, number>} */
   this.tagIndex_ = {};
 };
 
@@ -51,7 +51,6 @@ tachyfont.Sfnt.TableOfContents.CFF_VERSION_TAG = 'OTTO';
 
 /**
  * Factory to get a font table of contents.
- *
  * @param {DataView} fontData The font data.
  * @return {!tachyfont.Sfnt.TableOfContents}
  */
@@ -64,7 +63,6 @@ tachyfont.Sfnt.getTableOfContents = function(fontData) {
 
 /**
  * Initialize the Table Of Contents.
- *
  * @param {DataView} fontData The font data.
  * @private
  */
@@ -98,7 +96,6 @@ tachyfont.Sfnt.TableOfContents.prototype.init_ = function(fontData) {
 
 /**
  * Get a Table Of Contents table entry.
- *
  * @param {string} tag The 4 character tag for the table.
  * @return {tachyfont.Sfnt.TableOfContentsEntry} ;
  */
@@ -111,32 +108,30 @@ tachyfont.Sfnt.TableOfContents.prototype.getTocEntry = function(tag) {
 
 /**
  * An item in the Font table of contents.
- *
- * @param {!string} tag The table name.
- * @param {!number} checksum The checksum of the table.
- * @param {!number} offset The offset to the table.
- * @param {!number} length The length of the table.
+ * @param {string} tag The table name.
+ * @param {number} checksum The checksum of the table.
+ * @param {number} offset The offset to the table.
+ * @param {number} length The length of the table.
  * @constructor
  */
 tachyfont.Sfnt.TableOfContentsEntry = function(tag, checksum, offset, length) {
-  // @private {!string}
+  /** @private {string} */
   this.tag_ = tag;
 
-  // @private {!number}
+  /** @private {number} */
   this.checksum_ = checksum;
 
-  // @private {!number}
+  /** @private {number} */
   this.offset_ = offset;
 
-  // @private {!number}
+  /** @private {number} */
   this.length_ = length;
 };
 
 
 /**
  * Get the table offset from the beginning of the font to the table.
- *
- * @return {!number} The offset to the table.
+ * @return {number} The offset to the table.
  */
 tachyfont.Sfnt.TableOfContentsEntry.prototype.getOffset = function() {
   return this.offset_;

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfont.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfont.js
@@ -86,8 +86,8 @@ tachyfont.Error_ = {
  * @private
  */
 tachyfont.reportError_ = function(errNum, errInfo) {
-  if (tachyfont.reporter) {
-    tachyfont.reporter.reportError(tachyfont.Error_.FILE_ID + errNum, '000',
+  if (tachyfont.Reporter.isReady()) {
+    tachyfont.Reporter.reportError(tachyfont.Error_.FILE_ID + errNum, '000',
         errInfo);
   } else {
     var obj = {};
@@ -137,7 +137,6 @@ if (window.addEventListener) {
 if (goog.DEBUG) {
   /**
    * A class variable to limit debug initialization to a single time.
-   *
    * @private {boolean}
    */
   tachyfont.hasInitializedDebug_ = false;
@@ -275,26 +274,6 @@ tachyfont.IncrementalFontLoader;
 
 
 /**
- * Logging and error reporter.
- *
- * @type {!tachyfont.Reporter}
- */
-tachyfont.reporter;
-
-
-/**
- * Initialize the tachyfont reporter.
- *
- * @param {string} reportUrl The base url to send reports to.
- */
-tachyfont.initializeReporter = function(reportUrl) {
-  if (!tachyfont.reporter) {
-    tachyfont.reporter = tachyfont.Reporter.getReporter(reportUrl);
-  }
-};
-
-
-/**
  * Enum for logging values.
  * @enum {string}
  * @private
@@ -362,7 +341,7 @@ tachyfont.loadFonts_loadAndUse_ = function(tachyFontSet) {
       tachyFontSet.finishPrecedingUpdateFont.getChainedPromise(msg);
   waitForPrecedingPromise.getPrecedingPromise().
       then(function() {
-        tachyfont.reporter.addItem(tachyfont.Log_.LOAD_FONTS_WAIT_PREVIOUS +
+        tachyfont.Reporter.addItem(tachyfont.Log_.LOAD_FONTS_WAIT_PREVIOUS +
             '000', goog.now() - waitPreviousTime);
         if (goog.DEBUG) {
           goog.log.log(tachyfont.Logger.logger, goog.log.Level.FINER,
@@ -416,8 +395,8 @@ tachyfont.loadFonts_init_ = function(familyName, fontsInfo, opt_params) {
         (window.location.port ? ':' + window.location.port : '');
   }
   var reportUrl = fontsInfo.getReportUrl() || dataUrl;
-  tachyfont.initializeReporter(reportUrl);
-  tachyfont.reporter.addItemTime(tachyfont.Log_.LOAD_FONTS + '000');
+  tachyfont.Reporter.initReporter(reportUrl);
+  tachyfont.Reporter.addItemTime(tachyfont.Log_.LOAD_FONTS + '000');
 
   // Check if the persistent stores should be dropped.
   var uri = goog.Uri.parse(window.location.href);
@@ -470,7 +449,7 @@ tachyfont.loadFonts_getBaseFonts_ = function(tachyFonts) {
           } else {
             // If not persisted the fetch the base from the URL.
             arrayBaseData[i] = incrfont.getBaseFontFromUrl(
-                incrfont.backendService, incrfont.fontInfo);
+               incrfont.backendService, incrfont.fontInfo);
           }
         }
         return goog.Promise.all(arrayBaseData);
@@ -515,10 +494,10 @@ tachyfont.loadFonts_useFonts_ = function(tachyFonts, arrayBaseData) {
         then(function() {
           // Report Set Font Early.
           var weight = this.fontInfo.getWeight();
-          tachyfont.reporter.addItem(tachyfont.Log_.SWITCH_FONT +
+          tachyfont.Reporter.addItem(tachyfont.Log_.SWITCH_FONT +
               weight, goog.now() - incrFont.startTime);
           var deltaTime = goog.now() - this.sfeStart_;
-          tachyfont.reporter.addItem(
+          tachyfont.Reporter.addItem(
               tachyfont.Log_.SWITCH_FONT_DELTA_TIME + weight,
               deltaTime);
           if (goog.DEBUG) {

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfontpromise.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfontpromise.js
@@ -24,6 +24,7 @@ goog.require('goog.Promise');
 goog.require('goog.log');
 goog.require('goog.log.Level');
 goog.require('tachyfont.Logger');
+goog.require('tachyfont.Reporter');
 
 
 
@@ -84,13 +85,13 @@ tachyfont.promise.Error_ = {
  */
 tachyfont.promise.reportError_ = function(errNum, errInfo) {
   if (goog.DEBUG) {
-    if (!tachyfont.reporter) {
+    if (!tachyfont.Reporter.isReady()) {
       debugger; // Failed to report error.
       goog.log.error(tachyfont.Logger.logger, 'failed to report error');
     }
   }
-  if (tachyfont.reporter) {
-    tachyfont.reporter.reportError(tachyfont.promise.Error_.FILE_ID + errNum,
+  if (tachyfont.Reporter.isReady()) {
+    tachyfont.Reporter.reportError(tachyfont.promise.Error_.FILE_ID + errNum,
         '000', errInfo);
   }
 };

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfontset.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfontset.js
@@ -26,6 +26,7 @@ goog.require('goog.log.Level');
 goog.require('goog.style');
 goog.require('tachyfont.IncrementalFontUtils');
 goog.require('tachyfont.Logger');
+goog.require('tachyfont.Reporter');
 goog.require('tachyfont.chainedPromises');
 
 
@@ -140,13 +141,13 @@ tachyfont.TachyFontSet.Error_ = {
  */
 tachyfont.TachyFontSet.reportError_ = function(errNum, errObj) {
   if (goog.DEBUG) {
-    if (!tachyfont.reporter) {
+    if (!tachyfont.Reporter.isReady()) {
       debugger; // Failed to report the error.
       goog.log.error(tachyfont.Logger.logger, 'failed to report error');
     }
   }
-  if (tachyfont.reporter) {
-    tachyfont.reporter.reportError(
+  if (tachyfont.Reporter.isReady()) {
+    tachyfont.Reporter.reportError(
         tachyfont.TachyFontSet.Error_.FILE_ID + errNum, '000', errObj);
   }
 };
@@ -440,7 +441,7 @@ tachyfont.TachyFontSet.prototype.setFonts_ = function(startTime, loadResults) {
     var loadResult = loadResults[i];
     if (loadResult == null) {
       // No FOUT so 0 FOUT time.
-      tachyfont.reporter.addItem(setFontLogId + weight, 0);
+      tachyfont.Reporter.addItem(setFontLogId + weight, 0);
       allCssSet.push(goog.Promise.resolve(null));
       continue;
     }
@@ -452,13 +453,13 @@ tachyfont.TachyFontSet.prototype.setFonts_ = function(startTime, loadResults) {
     var cssSetResult = fontObj.setFont(fontData).
         then(function() {
           if (startTime == 0) {
-            tachyfont.reporter.addItemTime(
+            tachyfont.Reporter.addItemTime(
                 tachyfont.TachyFontSet.Log_.SET_FONT_DOM_LOADED + weight);
           } else if (startTime >= 0) {
-            tachyfont.reporter.addItem(setFontLogId + weight,
+            tachyfont.Reporter.addItem(setFontLogId + weight,
                 goog.now() - startTime);
           } else {
-            tachyfont.reporter.addItem(
+            tachyfont.Reporter.addItem(
                 tachyfont.TachyFontSet.Log_.SET_FONT_DELAYED + weight,
                 goog.now() + startTime);
           }
@@ -563,7 +564,7 @@ tachyfont.TachyFontSet.prototype.updateFonts =
           goog.log.fine(tachyfont.Logger.logger,
               'updateFonts: updated all fonts');
         }
-        tachyfont.reporter.sendReport(okIfNoItems);
+        tachyfont.Reporter.sendReport(okIfNoItems);
         allUpdated.resolve();
       }.bind(this)).
       thenCatch(function(e) {


### PR DESCRIPTION
- tachyfont.js provides tachyfont.logger to the same files that it goog.requires. 
- Move the logger to a separate class/file.

Add some missing goog.require statements.
Remove some unneeded goog.require statements.
Remove or comment out some unneeded variables.