### PR TITLE
Break a circular dependency for several tachyfont.IncrementalFont

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/backendservice.js
+++ b/run_time/src/gae_server/www/js/tachyfont/backendservice.js
@@ -25,6 +25,7 @@ goog.require('goog.events');
 goog.require('goog.functions');
 goog.require('goog.net.EventType');
 goog.require('goog.net.XhrIo');
+/** @suppress {extraRequire} */
 goog.require('tachyfont.FontInfo');
 goog.require('tachyfont.GlyphBundleResponse');
 

--- a/run_time/src/gae_server/www/js/tachyfont/demobackendservice.js
+++ b/run_time/src/gae_server/www/js/tachyfont/demobackendservice.js
@@ -19,11 +19,7 @@
 
 goog.provide('tachyfont.DemoBackendService');
 
-goog.require('goog.events');
-goog.require('goog.net.EventType');
-goog.require('goog.net.XhrIo');
 goog.require('tachyfont.BackendService');
-goog.require('tachyfont.FontInfo');
 
 
 goog.scope(function() {

--- a/run_time/src/gae_server/www/js/tachyfont/fontsinfo.js
+++ b/run_time/src/gae_server/www/js/tachyfont/fontsinfo.js
@@ -19,6 +19,7 @@
 
 goog.provide('tachyfont.FontsInfo');
 
+/** @suppress {extraRequire} */
 goog.require('tachyfont.FontInfo');
 
 

--- a/run_time/src/gae_server/www/js/tachyfont/glyphbundleresponse.js
+++ b/run_time/src/gae_server/www/js/tachyfont/glyphbundleresponse.js
@@ -19,7 +19,6 @@
 
 goog.provide('tachyfont.GlyphBundleResponse');
 
-goog.require('goog.log');
 goog.require('tachyfont.BinaryFontEditor');
 
 

--- a/run_time/src/gae_server/www/js/tachyfont/googlebackendservice.js
+++ b/run_time/src/gae_server/www/js/tachyfont/googlebackendservice.js
@@ -21,6 +21,7 @@ goog.provide('tachyfont.GoogleBackendService');
 
 goog.require('goog.Promise');
 goog.require('tachyfont.BackendService');
+/** @suppress {extraRequire} */
 goog.require('tachyfont.FontInfo');
 goog.require('tachyfont.utils');
 

--- a/run_time/src/gae_server/www/js/tachyfont/persist_idb.js
+++ b/run_time/src/gae_server/www/js/tachyfont/persist_idb.js
@@ -23,6 +23,7 @@ goog.require('goog.Promise');
 goog.require('goog.log');
 goog.require('tachyfont.Logger');
 goog.require('tachyfont.Reporter');
+goog.require('tachyfont.utils');
 
 
 /**
@@ -93,7 +94,7 @@ tachyfont.Persist.saveData = function(idb, name, data) {
 tachyfont.Persist.openIndexedDB = function(dbName, id) {
   var openIdb = new goog.Promise(function(resolve, reject) {
     var dbOpen = window.indexedDB.open(dbName,
-        tachyfont.IncrementalFont.VERSION);
+        tachyfont.utils.IDB_VERSION);
 
     dbOpen.onsuccess = function(e) {
       var db = e.target.result;
@@ -114,14 +115,14 @@ tachyfont.Persist.openIndexedDB = function(dbName, id) {
             id, 'onupgradeneeded error: ' + e.value);
         reject();
       };
-      if (db.objectStoreNames.contains(tachyfont.IncrementalFont.BASE)) {
-        db.deleteObjectStore(tachyfont.IncrementalFont.BASE);
+      if (db.objectStoreNames.contains(tachyfont.utils.IDB_BASE)) {
+        db.deleteObjectStore(tachyfont.utils.IDB_BASE);
       }
-      if (db.objectStoreNames.contains(tachyfont.IncrementalFont.CHARLIST)) {
-        db.deleteObjectStore(tachyfont.IncrementalFont.CHARLIST);
+      if (db.objectStoreNames.contains(tachyfont.utils.IDB_CHARLIST)) {
+        db.deleteObjectStore(tachyfont.utils.IDB_CHARLIST);
       }
-      db.createObjectStore(tachyfont.IncrementalFont.BASE);
-      db.createObjectStore(tachyfont.IncrementalFont.CHARLIST);
+      db.createObjectStore(tachyfont.utils.IDB_BASE);
+      db.createObjectStore(tachyfont.utils.IDB_CHARLIST);
     };
   });
   return openIdb;

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfont.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfont.js
@@ -18,7 +18,6 @@
  */
 
 goog.provide('tachyfont');
-goog.provide('tachyfont.IncrementalFontLoader');
 goog.provide('tachyfont.TachyFont');
 
 goog.require('goog.Promise');
@@ -27,6 +26,7 @@ goog.require('goog.debug.Console');
 goog.require('goog.debug.Logger');
 goog.require('goog.log');
 goog.require('goog.log.Level');
+/** @suppress {extraRequire} */
 goog.require('tachyfont.FontsInfo');
 goog.require('tachyfont.IncrementalFont');
 goog.require('tachyfont.IncrementalFontUtils');

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfontutils.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfontutils.js
@@ -23,6 +23,47 @@ goog.provide('tachyfont.utils.uint8');
 
 
 /**
+ * The IndexedDB version.
+ * Increment this number every time there is a change in the schema.
+ *
+ * @const {number}
+ */
+tachyfont.utils.IDB_VERSION = 2;
+
+
+/**
+ * The base name.
+ *
+ * @const {string}
+ */
+tachyfont.utils.IDB_BASE = 'base';
+
+
+/**
+ * The base is dirty (needs to be persisted) key.
+ *
+ * @const {string}
+ */
+tachyfont.utils.IDB_BASE_DIRTY = 'base_dirty';
+
+
+/**
+ * The char list name.
+ *
+ * @const {string}
+ */
+tachyfont.utils.IDB_CHARLIST = 'charlist';
+
+
+/**
+ * The charlist is dirty (needs to be persisted) key.
+ *
+ * @const {string}
+ */
+tachyfont.utils.IDB_CHARLIST_DIRTY = 'charlist_dirty';
+
+
+/**
  * Enable/disable using/saving persisted data.
  *
  * @type {boolean}
@@ -247,6 +288,8 @@ if (goog.DEBUG) {
       console.log('----------');
     }
   };
+
+
   /**
    * Convert a number to hex.
    * @param {number} number The number to convert to


### PR DESCRIPTION
variables.
Add a could tests for tachyfontutils.
Fix goog.provide/goog.require per gjslint.
Minor cleanups per gjslint.