### PR TITLE
Add a CffIndex.TYPE_BINARY_STRING type rather than passing an isBinary.

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/cff.js
+++ b/run_time/src/gae_server/www/js/tachyfont/cff.js
@@ -148,9 +148,8 @@ tachyfont.Cff = function(tocEntry, fontData) {
 
   /**
    * The offset to the Encodings table.
-   * @private {number}
+   * Note: CFF CID fonts do not have an Encodings table.
    */
-  this.encodingsOffset_;
 
   /**
    * The offset to the FS Select table.
@@ -246,7 +245,7 @@ tachyfont.Cff.prototype.readHeader_ = function() {
 tachyfont.Cff.prototype.readNameIndex_ = function() {
   this.nameIndexOffset_ = this.hdrSize_;
   this.nameIndex_ = new tachyfont.CffIndex('Name', this.nameIndexOffset_,
-      tachyfont.CffIndex.TYPE_STRING, false, this.binEd_);
+      tachyfont.CffIndex.TYPE_STRING, this.binEd_);
   this.nameIndex_.loadStrings(this.binEd_);
   if (goog.DEBUG) {
     this.nameIndex_.display(true, this.cffTableOffset_);
@@ -262,8 +261,7 @@ tachyfont.Cff.prototype.readTopDictIndex_ = function() {
   this.topDictIndexOffset_ =
       this.nameIndexOffset_ + this.nameIndex_.getLength();
   this.topDictIndex_ = new tachyfont.CffIndex('TopDICT',
-      this.topDictIndexOffset_, tachyfont.CffIndex.TYPE_DICT, true,
-      this.binEd_);
+      this.topDictIndexOffset_, tachyfont.CffIndex.TYPE_DICT, this.binEd_);
   if (goog.DEBUG) {
     this.topDictIndex_.setDictOperators(tachyfont.CffDict.TOP_DICT_OPERATORS);
   }
@@ -284,7 +282,7 @@ tachyfont.Cff.prototype.readStringIndex_ = function() {
   this.stringIndexOffset_ =
       this.topDictIndexOffset_ + this.topDictIndex_.getLength();
   this.stringIndex_ = new tachyfont.CffIndex('String', this.stringIndexOffset_,
-      tachyfont.CffIndex.TYPE_STRING, false, this.binEd_);
+      tachyfont.CffIndex.TYPE_STRING, this.binEd_);
   this.stringIndex_.loadStrings(this.binEd_);
   if (goog.DEBUG) {
     this.stringIndex_.display(true, this.cffTableOffset_);
@@ -300,12 +298,12 @@ tachyfont.Cff.prototype.readGlobalSubrIndex_ = function() {
   this.globalSubrIndexOffset_ = this.stringIndexOffset_ +
       this.stringIndex_.getLength();
   this.globalSubrIndex_ = new tachyfont.CffIndex('GlobalSubr',
-      this.globalSubrIndexOffset_, tachyfont.CffIndex.TYPE_STRING, true,
+      this.globalSubrIndexOffset_, tachyfont.CffIndex.TYPE_BINARY_STRING,
       this.binEd_);
   // To conserver memory do not process the data.
   // this.globalSubrIndex_.loadStrings(this.binEd_);
   //if (goog.DEBUG) {
-  //  this.stringIndex_.display(true, this.cffTableOffset_);
+  //  this.globalSubrIndex_.display(true, this.cffTableOffset_);
   //}
 };
 
@@ -320,7 +318,7 @@ tachyfont.Cff.prototype.getMajor = function() {
 
 
 /**
- * Get the CFF minor number;
+ * Get the CFF minor number.
  * @return {number}
  */
 tachyfont.Cff.prototype.getMinor = function() {

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfont.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfont.js
@@ -191,85 +191,6 @@ if (goog.DEBUG) {
     tachyfont.checkCmap = checkCmapStr.toLowerCase() == 'true';
   };
 }
-//
-//
-///**
-// * Enable/disable using/saving persisted data.
-// *
-// * @type {boolean}
-// */
-//tachyfont.persistData = true;
-//
-//
-///**
-// * A mapping from css weight names to weights.
-// *
-// * @type {!Object.<string, string>}
-// */
-//tachyfont.cssWeightToNumber = {
-//  'lighter': '300',
-//  'normal': '400',
-//  'bold': '700',
-//  'bolder': '800'
-//};
-//
-//
-///**
-// * A map of the codepoints that should be blank.
-// *
-// * @type {!Object.<number, number>}
-// */
-//tachyfont.BLANK_CHARS = {
-//  // White space characters.
-//  0x0009: 1, 0x000A: 1, 0x000B: 1, 0x000C: 1, 0x000D: 1, 0x0020: 1, 0x0085: 1,
-//  0x00A0: 1, 0x1680: 1, 0x2000: 1, 0x2001: 1, 0x2002: 1, 0x2003: 1, 0x2004: 1,
-//  0x2005: 1, 0x2006: 1, 0x2007: 1, 0x2008: 1, 0x2009: 1, 0x200A: 1, 0x2028: 1,
-//  0x2029: 1, 0x202F: 1, 0x205F: 1, 0x3000: 1,
-//
-//  // Default ignorable character set Source:
-//  // http://www.unicode.org/L2/L2002/02368-default-ignorable.pdf
-//  // "Default-ignorable code points ... have no visible glyph"
-//  0x00AD: 1, 0x034F: 1, 0x061C: 1, 0x115F: 1, 0x1160: 1, 0x17B4: 1, 0x17B5: 1,
-//  0x3164: 1, 0x180B: 1, 0x180C: 1, 0x180D: 1, 0x180E: 1, 0x200B: 1, 0x200C: 1,
-//  0x200D: 1, 0x200E: 1, 0x200F: 1, 0x202A: 1, 0x202B: 1, 0x202C: 1, 0x202D: 1,
-//  0x202E: 1, 0x2060: 1, 0x2061: 1, 0x2062: 1, 0x2063: 1, 0x2064: 1, 0x2065: 1,
-//  0x2066: 1, 0x2067: 1, 0x2068: 1, 0x2069: 1, 0x206A: 1, 0x206B: 1, 0x206C: 1,
-//  0x206D: 1, 0x206E: 1, 0x206F: 1, 0xFE00: 1, 0xFE01: 1, 0xFE02: 1, 0xFE03: 1,
-//  0xFE04: 1, 0xFE05: 1, 0xFE06: 1, 0xFE07: 1, 0xFE08: 1, 0xFE09: 1, 0xFE0A: 1,
-//  0xFE0B: 1, 0xFE0C: 1, 0xFE0D: 1, 0xFE0E: 1, 0xFE0F: 1, 0xFEFF: 1, 0xFFA0: 1,
-//  0x1D173: 1, 0x1D174: 1, 0x1D175: 1, 0x1D176: 1, 0x1D177: 1, 0x1D178: 1,
-//  0x1D179: 1, 0x1D17A: 1
-//};
-//
-//
-///**
-// * If the number of characters in the request is less than this count then add
-// * additional characters to obfuscate the actual request.
-// *
-// * @type {number}
-// */
-//tachyfont.MINIMUM_NON_OBFUSCATION_LENGTH = 20;
-//
-//
-///**
-// * The range of characters to pick from.
-// *
-// * @type {number}
-// */
-//tachyfont.OBFUSCATION_RANGE = 256;
-//
-//
-///**
-// * @typedef {number}
-// */
-//tachyfont.uint8;
-//
-//
-///**
-// * @typedef {Object}
-// * TODO(bstell): this probably belongs in BinaryFontEditor.
-// */
-//tachyfont.IncrementalFontLoader;
 
 
 /**
@@ -283,21 +204,6 @@ tachyfont.Log_ = {
   SWITCH_FONT: 'LTFSE.',
   SWITCH_FONT_DELTA_TIME: 'LTFSD.'
 };
-
-
-///**
-// * Create a font identifying string.
-// *
-// * @param {string} family The font family name;
-// * @param {string} weight The font weight;
-// * @return {string} The identifier for this font.
-// */
-//// TODO(bstell): merge this with getDbName
-//tachyfont.fontId = function(family, weight) {
-//  // TODO(bstell): need to support slant/width/etc.
-//  var fontId = family + ';' + weight;
-//  return fontId;
-//};
 
 
 /**
@@ -544,28 +450,6 @@ tachyfont.loadFonts_setupTextListeners_ = function(tachyFontSet) {
 };
 
 
-///**
-// * Convert a string to an array of characters.
-// * This function handles surrogate pairs.
-// *
-// * @param {string} str The input string.
-// * @return {Array.<string>} The array of characters.
-// */
-//tachyfont.stringToChars = function(str) {
-//  var charArray = [];
-//  for (var i = 0; i < str.length; i++) {
-//    var c = str.charAt(i);
-//    var cc = c.charCodeAt(0);
-//    if (cc >= 0xD800 && cc <= 0xDBFF) {
-//      i += 1;
-//      c += str.charAt(i);
-//    }
-//    charArray.push(c);
-//  }
-//  return charArray;
-//};
-//
-//
 /**
  * TachyFont DOM Mutation Observer
  *
@@ -624,26 +508,6 @@ tachyfont.loadFonts_domMutationObserver_ = function(tachyFontSet, mutations) {
 };
 
 
-///**
-// * Convert a char to its codepoint.
-// * This function handles surrogate pairs.
-// *
-// * @param {string} inputChar The input char (string).
-// * @return {number} The numeric value.
-// */
-//tachyfont.charToCode = function(inputChar) {
-//  var cc = inputChar.charCodeAt(0);
-//  if (cc >= 0xD800 && cc <= 0xDBFF) {
-//    var high = (cc - 0xD800) << 10;
-//    var low = inputChar.charCodeAt(1) - 0xDC00;
-//    var codepoint = high + low + 0x10000;
-//    return codepoint;
-//  } else {
-//    return cc;
-//  }
-//};
-//
-//
 /**
  * TachyFont DOM Mutation Observer
  *

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfontprelude.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfontprelude.js
@@ -68,8 +68,7 @@ tachyfontprelude.ERROR_BAD_MAGIC_NUMBER = 3;
  * The errors encounter while loading the Tachyfont preludes.
  * These will be reported by the TachyFont library.
  *
- * @type {Array.<Array.<string|number>>}
- * @private
+ * @private {Array.<Array.<string|number>>}
  */
 tachyfontprelude.reports_ = [];
 


### PR DESCRIPTION
Remove unused encodingsOffset field.
Change some comments.
Remove commented out code that was move to a different file in a
previous
checkin.