### PR TITLE
To CffIndex add a getDictElement that checks the INDEX type.

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/cff.js
+++ b/run_time/src/gae_server/www/js/tachyfont/cff.js
@@ -69,19 +69,7 @@ tachyfont.Cff = function(tocEntry, fontData) {
   this.binEd_;
 
   /**
-   * This font's CFF major version number.
-   * @private {number}
-   */
-  this.major_;
-
-  /**
-   * This font's CFF minor version number.
-   * @private {number}
-   */
-  this.minor_;
-
-  /**
-   * Size of the CFF Header.
+   * The Header size.
    * @private {number}
    */
   this.hdrSize_;
@@ -237,10 +225,12 @@ tachyfont.Cff.prototype.initBinaryEditor_ = function() {
  * @private
  */
 tachyfont.Cff.prototype.readHeader_ = function() {
-  this.major_ = this.binEd_.getUint8();
-  this.minor_ = this.binEd_.getUint8();
+  // Skip the major and minor number.
+  this.binEd_.skip(2);
   this.hdrSize_ = this.binEd_.getUint8();
-  this.offSize_ = this.binEd_.getUint8();
+  // Skip offSize.
+  this.binEd_.skip(1);
+  this.binEd_.seek(this.hdrSize);
 };
 
 
@@ -275,8 +265,7 @@ tachyfont.Cff.prototype.readTopDictIndex_ = function() {
   if (goog.DEBUG) {
     this.topDictIndex_.display(true, this.cffTableOffset_);
   }
-  this.topDict_ =
-      /** @type {!tachyfont.CffDict} */ (this.topDictIndex_.getElement(0));
+  this.topDict_ = this.topDictIndex_.getDictElement(0);
 };
 
 
@@ -375,23 +364,5 @@ tachyfont.Cff.prototype.readCharStringsIndex_ = function() {
   if (goog.DEBUG) {
     this.charStringsIndex_.display(true, this.cffTableOffset_);
   }
-};
-
-
-/**
- * Get the CFF major number.
- * @return {number}
- */
-tachyfont.Cff.prototype.getMajor = function() {
-  return this.major_;
-};
-
-
-/**
- * Get the CFF minor number.
- * @return {number}
- */
-tachyfont.Cff.prototype.getMinor = function() {
-  return this.minor_;
 };
 

--- a/run_time/src/gae_server/www/js/tachyfont/cff_index.js
+++ b/run_time/src/gae_server/www/js/tachyfont/cff_index.js
@@ -70,18 +70,14 @@ tachyfont.CffIndex = function(name, offset, type, binEd) {
   /** @private {!Array.<number>} */
   this.offsets_ = [];
 
-  // Handle an empty INDEX.
-  if (this.count_ == 0) {
-    this.tableLength_ = 2;
-    this.offSize_ = 0;
-    return;
-  }
+  // The spec says an empty INDEX is only 2 bytes long but all the fonts handled
+  // by TachyFont have been processed by fontTools and it always adds a 0x01
+  // byte for offSize and a single 0x01 byte for the offsets array.
 
   // Non-empty INDEX so collect the basic info.
   this.offSize_ = binEd.getUint8();
   this.offsets_ = [];
 
-  //debugger;
   for (var i = 0; i <= this.count_; i++) {
     var elementOffset = binEd.getOffset(this.offSize_);
     this.offsets_.push(elementOffset);
@@ -124,6 +120,24 @@ tachyfont.CffIndex.TYPE_DICT = 3;
 tachyfont.CffIndex.prototype.getElement = function(index) {
   if (index in this.elements_) {
     return this.elements_[index];
+  }
+  throw new RangeError('CFF ' + this.name_ + ' INDEX: invalid index: ' + index);
+};
+
+
+/**
+ * Get an INDEX DICT element.
+ * @param {number} index The index of the element.
+ * @return {!tachyfont.CffDict} The DICT element from the INDEX.
+ * @throws Error if is not a DICT index.
+ * @throws RangeError if index is not in the array.
+ */
+tachyfont.CffIndex.prototype.getDictElement = function(index) {
+  if (this.type_ != tachyfont.CffIndex.TYPE_DICT) {
+    throw new Error('not a DICT INDEX');
+  }
+  if (index in this.elements_) {
+    return /** @type {!tachyfont.CffDict} */ (this.elements_[index]);
   }
   throw new RangeError('CFF ' + this.name_ + ' INDEX: invalid index: ' + index);
 };

--- a/run_time/src/gae_server/www/js/tachyfont/sfnt.js
+++ b/run_time/src/gae_server/www/js/tachyfont/sfnt.js
@@ -94,7 +94,7 @@ tachyfont.Sfnt.Font.prototype.getTable = function(tableTag) {
 /**
  * Replace a table.
  * @param {string} tableTag The name of the table.
- * @param {!Array.<!Uint8Array>} data The new table contents.
+ * @param {!Array.<!Array.<!Uint8Array>>} data The new table contents.
  */
 tachyfont.Sfnt.Font.prototype.replaceTable = function(tableTag, data) {
   var entry = this.tableOfContents_.getTocEntry(tableTag);
@@ -107,20 +107,22 @@ tachyfont.Sfnt.Font.prototype.replaceTable = function(tableTag, data) {
  * Replace a block of data.
  * @param {number} offset Where to insert the new data.
  * @param {number} length How much old data to remove.
- * @param {!Array.<!Uint8Array>} data The new table contents.
+ * @param {!Array.<!Array.<!Uint8Array>>} data The new table contents.
  * @return {number} The delta size change.
  * @private
  */
 tachyfont.Sfnt.Font.prototype.replaceData_ = function(offset, length, data) {
   // Get the new table size;
-  var dataLength = data.length, newTableLength = 0;
-  for (var i = 0; i < dataLength; i++) {
-    newTableLength += data[i].byteLength;
+  var newTableLength = 0;
+  for (var i = 0; i < data.length; i++) {
+    var dataGroup = data[i];
+    for (var j = 0; j < dataGroup.length; j++) {
+      newTableLength += dataGroup[j].byteLength;
+    }
   }
 
   var dataBefore = new Uint8Array(this.fontData_.buffer, 0, offset);
   var dataAfter = new Uint8Array(this.fontData_.buffer, offset + length);
-
 
   // Merge the data into a single buffer.
   // TODO(bstell): does the data really need to be in a single ArrayBuffer?
@@ -132,9 +134,12 @@ tachyfont.Sfnt.Font.prototype.replaceData_ = function(offset, length, data) {
   var newFontData = new Uint8Array(this.fontData_.byteLength + deltaSize);
   newFontData.set(dataBefore);
   var position = dataBefore.byteLength;
-  for (var i = 0; i < dataLength; i++) {
-    newFontData.set(data[i], position);
-    position += data[i].byteLength;
+  for (var i = 0; i < data.length; i++) {
+    var dataGroup = data[i];
+    for (var j = 0; j < dataGroup.length; j++) {
+      newFontData.set(dataGroup[j], position);
+      position += dataGroup[j].byteLength;
+    }
   }
   newFontData.set(dataAfter, position);
 


### PR DESCRIPTION
To avoid an extra copy of the (multi-megabyte) CharStrings INDEX pass it
in as an array-of blocks => When replacing a table pass in a array-of
array-of data blocks.