### PR TITLE
Add/use accessor functions to private variables.

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/binaryfonteditor.js
+++ b/run_time/src/gae_server/www/js/tachyfont/binaryfonteditor.js
@@ -25,7 +25,7 @@ goog.provide('tachyfont.BinaryFontEditor');
  * Binary Font Editor - A namespace.
  * Binary operation over font file or glyph bundle.
  * Always big endian byte order.
- * @param {DataView} dataView DataView which includes data
+ * @param {!DataView} dataView DataView which includes data
  * @param {number} baseOffset Set this offset as 0 offset for operations
  * @constructor
  */

--- a/run_time/src/gae_server/www/js/tachyfont/cff_index.js
+++ b/run_time/src/gae_server/www/js/tachyfont/cff_index.js
@@ -64,18 +64,16 @@ tachyfont.CffIndex = function(name, offset, type, binEd) {
   /** @private {number} */
   this.count_ = binEd.getUint16();
 
-  /** @private {number} */
-  this.offSize_;
+  /**
+   * Note: not following the CFF spec here.
+   * The spec says an empty INDEX is only 2 bytes long but all the fonts handled
+   * by TachyFont have been processed by fontTools and it always adds a 0x01
+   * byte for offSize and a single 0x01 byte for the offsets array.
+   * @private {number}
+   */
+  this.offSize_ = binEd.getUint8();
 
   /** @private {!Array.<number>} */
-  this.offsets_ = [];
-
-  // The spec says an empty INDEX is only 2 bytes long but all the fonts handled
-  // by TachyFont have been processed by fontTools and it always adds a 0x01
-  // byte for offSize and a single 0x01 byte for the offsets array.
-
-  // Non-empty INDEX so collect the basic info.
-  this.offSize_ = binEd.getUint8();
   this.offsets_ = [];
 
   for (var i = 0; i <= this.count_; i++) {
@@ -156,6 +154,15 @@ if (goog.DEBUG) {
 
 
 /**
+ * Get the offSize of elements.
+ * @return {number} The offSize of elements.
+ */
+tachyfont.CffIndex.prototype.getOffSize = function() {
+  return this.offSize_;
+};
+
+
+/**
  * Get the count of elements.
  * @return {number} The count of elements.
  */
@@ -165,11 +172,50 @@ tachyfont.CffIndex.prototype.getCount = function() {
 
 
 /**
+ * Get the elements.
+ * @return {!Array.<string|!DataView|!tachyfont.CffDict>} The elements.
+ */
+tachyfont.CffIndex.prototype.getElements = function() {
+  return this.elements_;
+};
+
+
+/**
+ * Get the element's offset from the beginning of the index.
+ * @param {number} index The index to get the offset for.
+ * @return {number} The element's offset.
+ */
+tachyfont.CffIndex.prototype.getAdjustedElementOffset = function(index) {
+  var offset = 2 + 1 + (this.offSize_ * (this.count_ + 1)) - 1;
+  offset += this.offsets_[index];
+  return offset;
+};
+
+
+/**
+ * Get the element offsets.
+ * @return {!Array.<number>} The element offsets.
+ */
+tachyfont.CffIndex.prototype.getOffsets = function() {
+  return this.offsets_;
+};
+
+
+/**
  * Get the table length.
  * @return {number} The length of the table.
  */
 tachyfont.CffIndex.prototype.getLength = function() {
   return this.tableLength_;
+};
+
+
+/**
+ * Get the table type.
+ * @return {number} The type of the table.
+ */
+tachyfont.CffIndex.prototype.getType = function() {
+  return this.type_;
 };
 
 

--- a/run_time/src/gae_server/www/js/tachyfont/cmap.js
+++ b/run_time/src/gae_server/www/js/tachyfont/cmap.js
@@ -330,9 +330,9 @@ tachyfont.Cmap.checkCharacters = function(fileInfo, baseFontView,
  * Note: this is not well tested.
  *
  * @param {!Object} fileInfo Information about the font file.
- * @param {DataView} baseFontView Current base font
- * @param {Array.<number>} glyphIds The glyph Ids to set.
- * @param {Object.<number, Array.<number>>} glyphToCodeMap The glyph Id to code
+ * @param {!DataView} baseFontView Current base font
+ * @param {!Array.<number>} glyphIds The glyph Ids to set.
+ * @param {!Object.<number, Array.<number>>} glyphToCodeMap The glyph Id to code
  *     point mapping;
  * @param {!Object.<number, !tachyfont.CharCmapInfo>} cmapMapping Information
  *     about the cmap segments for the codepoint.
@@ -454,9 +454,9 @@ tachyfont.Cmap.setFormat4GlyphIds = function(fileInfo, baseFontView, glyphIds,
  * Set the format 12 glyph Ids.
  *
  * @param {!Object} fileInfo Information about the font file.
- * @param {DataView} baseFontView Current base font
- * @param {Array.<number>} glyphIds The glyph Ids to set.
- * @param {Object.<number, Array.<number>>} glyphToCodeMap The glyph Id to code
+ * @param {!DataView} baseFontView Current base font
+ * @param {!Array.<number>} glyphIds The glyph Ids to set.
+ * @param {!Object.<number, Array.<number>>} glyphToCodeMap The glyph Id to code
  *     point mapping;
  * @param {!Object.<number, !tachyfont.CharCmapInfo>} cmapMapping Information
  *     about the cmap segments for the codepoint.

--- a/run_time/src/gae_server/www/js/tachyfont/incrementalfont.js
+++ b/run_time/src/gae_server/www/js/tachyfont/incrementalfont.js
@@ -475,7 +475,7 @@ tachyfont.IncrementalFont.obj_.prototype.getBaseFontFromPersistence =
 
 /**
  * Parses base font header, set properties.
- * @param {DataView} baseFontView Base font with header.
+ * @param {!DataView} baseFontView Base font with header.
  */
 tachyfont.IncrementalFont.obj_.prototype.parseBaseHeader =
     function(baseFontView) {
@@ -545,14 +545,14 @@ tachyfont.IncrementalFont.obj_.prototype.processUrlBase_ =
 
 /**
  * Inject glyphs in the glyphData to the baseFontView
- * @param {DataView} baseFontView Current base font
- * @param {tachyfont.GlyphBundleResponse} bundleResponse New glyph data
- * @param {Object.<number, Array.<number>>} glyphToCodeMap An input and output
+ * @param {!DataView} baseFontView Current base font
+ * @param {!tachyfont.GlyphBundleResponse} bundleResponse New glyph data
+ * @param {!Object.<number, Array.<number>>} glyphToCodeMap An input and output
  *     value.
  *       Input: the glyph Id to code point mapping;
  *       Output: the glyph Ids that were expected but not in the bundleResponse.
- * @param {Array.<number>} extraGlyphs An output list of the extra glyph Ids.
- * @return {DataView} Updated base font
+ * @param {!Array.<number>} extraGlyphs An output list of the extra glyph Ids.
+ * @return {!DataView} Updated base font
  */
 tachyfont.IncrementalFont.obj_.prototype.injectCharacters =
     function(baseFontView, bundleResponse, glyphToCodeMap, extraGlyphs) {

--- a/run_time/src/gae_server/www/js/tachyfont/incrementalfontutils.js
+++ b/run_time/src/gae_server/www/js/tachyfont/incrementalfontutils.js
@@ -61,8 +61,8 @@ tachyfont.IncrementalFontUtils.STYLESHEET_ID =
 
 /**
  * Parses base font header, set properties.
- * @param {DataView} baseFont Base font with header.
- * @param {Object} headerInfo Header information
+ * @param {!DataView} baseFont Base font with header.
+ * @param {!Object} headerInfo Header information
  */
 tachyfont.IncrementalFontUtils.writeCharsetFormat2 =
     function(baseFont, headerInfo) {
@@ -85,9 +85,9 @@ tachyfont.IncrementalFontUtils.writeCharsetFormat2 =
 
 /**
  * Sanitize base font to pass OTS
- * @param {Object} headerInfo The font header information.
- * @param {DataView} baseFont Base font as DataView
- * @return {DataView} Sanitized base font
+ * @param {!Object} headerInfo The font header information.
+ * @param {!DataView} baseFont Base font as DataView
+ * @return {!DataView} Sanitized base font
  */
 tachyfont.IncrementalFontUtils.sanitizeBaseFont =
     function(headerInfo, baseFont) {

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfontlogger.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfontlogger.js
@@ -30,6 +30,14 @@ if (goog.DEBUG) {
   tachyfont.Logger.hasInitialized_ = false;
 
   /**
+   * For test allow reinitializing the logger.
+   * @param {boolean} hasInitialized
+   */
+  tachyfont.Logger.setHasInitialized = function(hasInitialized) {
+    tachyfont.Logger.hasInitialized_ = hasInitialized;
+  };
+
+  /**
    * Initialize the logger.
    * @param {goog.debug.Logger.Level} debugLevel The desired debug level.
    */

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfontreporter.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfontreporter.js
@@ -54,9 +54,9 @@ tachyfont.Reporter.startTime_ = goog.now();
 /**
  * TachyFont singleton object.
  *
- * @private {!tachyfont.Reporter|undefined}
+ * @private {tachyfont.Reporter}
  */
-tachyfont.Reporter.instance_;
+tachyfont.Reporter.instance_ = null;
 
 
 /**
@@ -64,7 +64,7 @@ tachyfont.Reporter.instance_;
  * @return {boolean} Whether the reporter has been initialized.
  */
 tachyfont.Reporter.isReady = function() {
-  return typeof tachyfont.Reporter.instance_ == 'object';
+  return tachyfont.Reporter.instance_ != null;
 };
 
 
@@ -73,7 +73,7 @@ tachyfont.Reporter.isReady = function() {
  * @param {string} url The base URL to send reports to.
  */
 tachyfont.Reporter.initReporter = function(url) {
-  if (!tachyfont.Reporter.instance_) {
+  if (tachyfont.Reporter.instance_ == null) {
     tachyfont.Reporter.instance_ = new tachyfont.Reporter(url);
   }
 };
@@ -83,7 +83,7 @@ tachyfont.Reporter.initReporter = function(url) {
  * Reset the reporter singleton.
  */
 tachyfont.Reporter.reset = function() {
-  tachyfont.Reporter.instance_ = undefined;
+  tachyfont.Reporter.instance_ = null;
 };
 
 


### PR DESCRIPTION
Use null for an 'uninitialized' tachyfont.Report instance so tests can
reset it.
Use a unique name for the test CSS names (appears the DOM persists
across tests).
Remove a test that tests a private method.
Remove a duplicate function.
Address warnings from compiling the tests.
Mark some JsDoc types as not-null.
Slight reworking of the info in comments in a test data file.
Save the tag from the sfnt table of content as a number (in addition to
as a string).