### PR TITLE
In binaryfonteditor.js

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/backendservice.js
+++ b/run_time/src/gae_server/www/js/tachyfont/backendservice.js
@@ -83,7 +83,7 @@ BackendService.prototype.requestFontBase = goog.functions.NULL;
  * Parses the header of a codepoint response and returns info on it:
  *
  * @param {ArrayBuffer} glyphData from a code point request.
- * @return {tachyfont.GlyphBundleResponse}
+ * @return {!tachyfont.GlyphBundleResponse}
  */
 BackendService.prototype.parseDataHeader = function(glyphData) {
   var dataView = new DataView(glyphData);

--- a/run_time/src/gae_server/www/js/tachyfont/binaryfonteditor.js
+++ b/run_time/src/gae_server/www/js/tachyfont/binaryfonteditor.js
@@ -197,7 +197,7 @@ tachyfont.BinaryFontEditor.prototype.setOffset_ = function(offSize, value) {
  * @return {!DataView}
  */
 tachyfont.BinaryFontEditor.prototype.readDataView = function(length) {
-  var offset = this.baseOffset + this.offset;
+  var offset = this.dataView.byteOffset + this.baseOffset + this.offset;
   var dataView = new DataView(this.dataView.buffer, offset, length);
   this.offset += length;
   return dataView;


### PR DESCRIPTION
- in readDataView use the DataView byteOffset.

In cff.js
- in the constructor pass in the offset instead of a
TableOfContentsEntry
- create the binaryFontEditor in the constructor
- remove the initBinaryEditor routine
- remove some debug statements
- add convenience routines
  - getCharStringIndex
  - getTopDictOperand

In sfnt.js
- add a sorted (by file offset) table of contents
- handle table allocation sizes separately from the table size
  - allocation size = table size + padding size
  - when replacing a table size the padding to align the next table on a
long
- add convenience routines
  - getTableEntry
  - getTableOffset
- rename getTable to getTableData as it gets the data
- rename getTableOfContents to parseTableOfContents
  - it actually parses the table of contents
  - avoid possible confusion
    - this class method name was the same as the instance method name
  - make it private
- remove isCff in favor of getIsCff


Fix minor Closure annotation change.