### PR TITLE
Process the glyph request bytes into a sorted array of objects.

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/backendservice.js
+++ b/run_time/src/gae_server/www/js/tachyfont/backendservice.js
@@ -113,12 +113,8 @@ BackendService.prototype.parseDataHeader = function(glyphData) {
     }
     signature += thisByteStr;
   }
-  var count = dataView.getUint16(offset);
-  offset += 2;
-  var flags = dataView.getUint16(offset);
-  offset += 2;
-  return new tachyfont.GlyphBundleResponse(
-      version, signature, count, flags, offset, glyphData);
+  return new tachyfont.GlyphBundleResponse(version, signature, offset,
+      glyphData);
 };
 
 

--- a/run_time/src/gae_server/www/js/tachyfont/binaryfonteditor.js
+++ b/run_time/src/gae_server/www/js/tachyfont/binaryfonteditor.js
@@ -116,7 +116,7 @@ tachyfont.BinaryFontEditor.prototype.getInt32_ = function() {
 /**
  * @param {function()} getter One of getUint or getInt functions
  * @param {number} count Size of array
- * @return {Array.<number>}
+ * @return {!Array.<number>}
  */
 tachyfont.BinaryFontEditor.prototype.getArrayOf = function(getter, count) {
   var arr = [];

--- a/run_time/src/gae_server/www/js/tachyfont/glyphbundleresponse.js
+++ b/run_time/src/gae_server/www/js/tachyfont/glyphbundleresponse.js
@@ -20,26 +20,54 @@
 goog.provide('tachyfont.GlyphBundleResponse');
 
 goog.require('tachyfont.BinaryFontEditor');
+goog.require('tachyfont.IncrementalFontUtils');
 
 
 
 /**
  * @param {string} version
  * @param {string} signature
- * @param {number} count
- * @param {number} flags
- * @param {number} offsetToGlyphData
- * @param {ArrayBuffer} glyphData
- * @constructor
+ * @param {number} offset Offset to the GlyphBundle Bytes
+ * @param {ArrayBuffer} buffer The glyph response buffer.
+ * @constructor @final @struct
  */
-tachyfont.GlyphBundleResponse = function(
-    version, signature, count, flags, offsetToGlyphData, glyphData) {
+tachyfont.GlyphBundleResponse = function(version, signature, offset, buffer) {
+  var dataView = new DataView(buffer);
+  var binEd = new tachyfont.BinaryFontEditor(dataView, offset);
+  var count = binEd.getUint16();
+  var flags = binEd.getUint16();
+
   this.version = version;
   this.signature = signature;
   this.count = count;
   this.flags = flags;
-  this.offsetToGlyphData = offsetToGlyphData;
-  this.glyphData = glyphData;
+  this.offsetToGlyphData = offset + 4;
+  this.glyphBuffer = buffer;
+  this.glyphDataArray_ = [];
+
+  for (var i = 0; i < count; i += 1) {
+    var id = binEd.getUint16();
+    var hmtx, vmtx;
+    if (flags & tachyfont.IncrementalFontUtils.FLAGS.HAS_HMTX) {
+      hmtx = binEd.getUint16();
+    }
+    if (flags & tachyfont.IncrementalFontUtils.FLAGS.HAS_VMTX) {
+      vmtx = binEd.getUint16();
+    }
+
+    var bytesOffset = binEd.getUint32();
+    var length = binEd.getUint16();
+
+    var bytes = binEd.getArrayOf(binEd.getUint8, length);
+
+    var glyphData = new tachyfont.GlyphBundleResponse.GlyphData(id, hmtx, vmtx,
+        bytesOffset, length, bytes);
+    this.glyphDataArray_.push(glyphData);
+  }
+  // Sort the glyphData entries by glyph id.
+  this.glyphDataArray_.sort(function(a, b) {
+    return a.getId() - b.getId();
+  });
 };
 
 
@@ -47,7 +75,7 @@ tachyfont.GlyphBundleResponse = function(
  * @return {number} the length of the glyph data in this response.
  */
 tachyfont.GlyphBundleResponse.prototype.getDataLength = function() {
-  return this.glyphData.byteLength - this.offsetToGlyphData;
+  return this.glyphBuffer.byteLength - this.offsetToGlyphData;
 };
 
 
@@ -56,7 +84,7 @@ tachyfont.GlyphBundleResponse.prototype.getDataLength = function() {
  *         response.
  */
 tachyfont.GlyphBundleResponse.prototype.getFontEditor = function() {
-  return new tachyfont.BinaryFontEditor(new DataView(this.glyphData),
+  return new tachyfont.BinaryFontEditor(new DataView(this.glyphBuffer),
                                         this.offsetToGlyphData);
 };
 
@@ -75,3 +103,93 @@ tachyfont.GlyphBundleResponse.prototype.getGlyphCount = function() {
 tachyfont.GlyphBundleResponse.prototype.getFlags = function() {
   return this.flags;
 };
+
+
+/**
+ * @return {!Array.<!tachyfont.GlyphBundleResponse.GlyphData>}
+ */
+tachyfont.GlyphBundleResponse.prototype.getGlyphDataArray = function() {
+  return this.glyphDataArray_;
+};
+
+
+
+/**
+ * @param {number} id
+ * @param {number|undefined} hmtx
+ * @param {number|undefined} vmtx
+ * @param {number} offset
+ * @param {number} length
+ * @param {!Array.<number>} bytes
+ * @constructor @final @struct
+ */
+tachyfont.GlyphBundleResponse.GlyphData = function(id, hmtx, vmtx, offset,
+    length, bytes) {
+  /** @private {number} */
+  this.id_ = id;
+
+  /** @private {number|undefined} */
+  this.hmtx_ = hmtx;
+
+  /** @private {number|undefined} */
+  this.vmtx_ = vmtx;
+
+  /** @private {number} */
+  this.offset_ = offset;
+
+  /** @private {number} */
+  this.length_ = length;
+
+  /** @private {!Array.<number>} */
+  this.bytes_ = bytes;
+};
+
+
+/**
+ * @return {number}
+ */
+tachyfont.GlyphBundleResponse.GlyphData.prototype.getId = function() {
+  return this.id_;
+};
+
+
+/**
+ * @return {number|undefined}
+ */
+tachyfont.GlyphBundleResponse.GlyphData.prototype.getHmtx = function() {
+  return this.hmtx_;
+};
+
+
+/**
+ * @return {number|undefined}
+ */
+tachyfont.GlyphBundleResponse.GlyphData.prototype.getVmtx = function() {
+  return this.vmtx_;
+};
+
+
+/**
+ * @return {number}
+ */
+tachyfont.GlyphBundleResponse.GlyphData.prototype.getOffset = function() {
+  return this.offset_;
+};
+
+
+/**
+ * @return {number}
+ */
+tachyfont.GlyphBundleResponse.GlyphData.prototype.getLength = function() {
+  return this.length_;
+};
+
+
+/**
+ * @return {!Array.<number>}
+ */
+tachyfont.GlyphBundleResponse.GlyphData.prototype.getBytes = function() {
+  return this.bytes_;
+};
+
+


### PR DESCRIPTION
In glyphbundleresponse.js
- add a GlyphData object
- process the glyph bytes into objects
- sort the GlyphData objects in an array


In backendservice.js
- move processing of the count and flags to
tachyfont.GlyphBundleResponse

Minor Closure annotation changes.