### PR TITLE
If there is enough available storage to store all fonts then do not

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/cmap.js
+++ b/run_time/src/gae_server/www/js/tachyfont/cmap.js
@@ -65,9 +65,8 @@ tachyfont.Cmap.Error = {
  * @param {string} errNum The error number;
  * @param {string} errId Identifies the error.
  * @param {*} errInfo The error object;
- * @private
  */
-tachyfont.Cmap.reportError_ = function(errNum, errId, errInfo) {
+tachyfont.Cmap.reportError = function(errNum, errId, errInfo) {
   if (goog.DEBUG) {
     if (!tachyfont.Reporter.isReady()) {
       goog.log.error(tachyfont.Logger.logger, 'failed to report error');
@@ -119,7 +118,7 @@ tachyfont.Cmap.writeCmap4 = function(fileInfo, baseFontView, weight) {
       fileInfo.cmap4.offset + 6);
   var segCount = binaryEditor.getUint16() / 2;
   if (segCount != segments.length) {
-    tachyfont.Cmap.reportError_(
+    tachyfont.Cmap.reportError(
         tachyfont.Cmap.Error.WRITE_CMAP4_SEGMENT_COUNT,
         weight, 'segCount=' + segCount +
         ', segments.length=' + segments.length);
@@ -285,37 +284,37 @@ tachyfont.Cmap.checkCharacters = function(fileInfo, baseFontView,
   }
   //  Report errors.
   if (charInfoErrors.length != 0) {
-    tachyfont.Cmap.reportError_(
+    tachyfont.Cmap.reportError(
         tachyfont.Cmap.Error.FORMAT12_CHAR_INFO, weight,
         charInfoErrors.toString());
   }
   if (startCodeErrors.length != 0) {
-    tachyfont.Cmap.reportError_(
+    tachyfont.Cmap.reportError(
         tachyfont.Cmap.Error.FORMAT12_START_CODE2, weight,
         startCodeErrors.toString());
   }
   if (endCodeErrors.length != 0) {
-    tachyfont.Cmap.reportError_(
+    tachyfont.Cmap.reportError(
         tachyfont.Cmap.Error.FORMAT12_END_CODE2, weight,
         endCodeErrors.toString());
   }
   if (glyphIdErrors.length != 0) {
-    tachyfont.Cmap.reportError_(
+    tachyfont.Cmap.reportError(
         tachyfont.Cmap.Error.FORMAT12_GLYPH_ID_NOT_SET, weight,
         glyphIdErrors.toString());
   }
   if (cmapErrors.length != 0) {
-    tachyfont.Cmap.reportError_(
+    tachyfont.Cmap.reportError(
         tachyfont.Cmap.Error.FORMAT12_CMAP_ERROR, weight,
         cmapErrors.toString());
   }
   if (glyphLengthErrors.length != 0) {
-    tachyfont.Cmap.reportError_(
+    tachyfont.Cmap.reportError(
         tachyfont.Cmap.Error.FORMAT12_GLYPH_LENGTH_ERROR, weight,
         glyphLengthErrors.toString());
   }
   if (glyphDataErrors.length != 0) {
-    tachyfont.Cmap.reportError_(
+    tachyfont.Cmap.reportError(
         tachyfont.Cmap.Error.FORMAT12_GLYPH_DATA_ERROR, weight,
         glyphDataErrors.toString());
   }
@@ -347,7 +346,7 @@ tachyfont.Cmap.setFormat4GlyphIds = function(fileInfo, baseFontView, glyphIds,
       fileInfo.cmap4.offset + 6);
   var segCount = binaryEditor.getUint16() / 2;
   if (segCount != segments.length) {
-    tachyfont.Cmap.reportError_(
+    tachyfont.Cmap.reportError(
         tachyfont.Cmap.Error.FORMAT4_SEGMENT_COUNT,
         weight, 'segCount=' + segCount + ', segments.length=' +
         segments.length);
@@ -358,7 +357,7 @@ tachyfont.Cmap.setFormat4GlyphIds = function(fileInfo, baseFontView, glyphIds,
     // Check the end code.
     var segmentEndCode = binaryEditor.getUint16();
     if (segmentEndCode != segments[i][1]) {
-      tachyfont.Cmap.reportError_(
+      tachyfont.Cmap.reportError(
           tachyfont.Cmap.Error.FORMAT4_END_CODE,
           weight, 'segment ' + i + ': segmentEndCode (' + segmentEndCode +
           ') != segments[' + i + '][1] (' + segments[i][1] + ')');
@@ -366,7 +365,7 @@ tachyfont.Cmap.setFormat4GlyphIds = function(fileInfo, baseFontView, glyphIds,
     }
     // Check the segment is one char long
     if (segmentEndCode != segments[i][0]) {
-      tachyfont.Cmap.reportError_(
+      tachyfont.Cmap.reportError(
           tachyfont.Cmap.Error.FORMAT4_SEGMENT_LENGTH,
           weight, 'segment ' + i +
           ' is ' + (segments[i][1] - segments[i][0] + 1) + ' chars long');
@@ -377,7 +376,7 @@ tachyfont.Cmap.setFormat4GlyphIds = function(fileInfo, baseFontView, glyphIds,
   for (var i = 0; i < segCount; i++) {
     var segStartCode = binaryEditor.getUint16();
     if (segStartCode != segments[i][0]) {
-      tachyfont.Cmap.reportError_(
+      tachyfont.Cmap.reportError(
           tachyfont.Cmap.Error.FORMAT4_START_CODE,
           weight, 'segment ' + i +
           ': segStartCode (' + segStartCode + ') != segments[' + i + '][1] (' +
@@ -390,7 +389,7 @@ tachyfont.Cmap.setFormat4GlyphIds = function(fileInfo, baseFontView, glyphIds,
     var segIdDelta = binaryEditor.getUint16();
     var segGlyphId = (segIdDelta + segments[i][0]) & 0xFFFF;
     if (segGlyphId != 0) {
-      tachyfont.Cmap.reportError_(
+      tachyfont.Cmap.reportError(
           tachyfont.Cmap.Error.FORMAT4_GLYPH_ID_ALREADY_SET,
           weight, 'format 4 segment ' + i + ': segIdDelta (' + segIdDelta +
           ') != segments[' + i + '][1] (' + segments[i][2] + ')');
@@ -406,7 +405,7 @@ tachyfont.Cmap.setFormat4GlyphIds = function(fileInfo, baseFontView, glyphIds,
   for (var i = 0; i < segCount; i++) {
     var segIdRangeOffset = binaryEditor.getUint16();
     if (segIdRangeOffset != 0) {
-      tachyfont.Cmap.reportError_(
+      tachyfont.Cmap.reportError(
           tachyfont.Cmap.Error.FORMAT4_ID_RANGE_OFFSET,
           weight, 'format 4 segment ' + i + ': segIdRangeOffset (' +
           segIdRangeOffset + ') != 0');
@@ -427,7 +426,7 @@ tachyfont.Cmap.setFormat4GlyphIds = function(fileInfo, baseFontView, glyphIds,
       }
       var charCmapInfo = cmapMapping[code];
       if (!charCmapInfo) {
-        tachyfont.Cmap.reportError_(
+        tachyfont.Cmap.reportError(
             tachyfont.Cmap.Error.FORMAT4_CHAR_CMAP_INFO,
             weight, 'format 4, code ' + code + ': no CharCmapInfo');
         continue;
@@ -435,7 +434,7 @@ tachyfont.Cmap.setFormat4GlyphIds = function(fileInfo, baseFontView, glyphIds,
       var format4Seg = charCmapInfo.format4Seg;
       if (format4Seg == null) {
         if (code <= 0xFFFF) {
-          tachyfont.Cmap.reportError_(
+          tachyfont.Cmap.reportError(
               tachyfont.Cmap.Error.FORMAT4_SEGMENT,
               weight, 'format 4, missing segment for code ' + code);
         }
@@ -483,7 +482,7 @@ tachyfont.Cmap.setFormat12GlyphIds = function(fileInfo, baseFontView, glyphIds,
       }
       var charCmapInfo = cmapMapping[code];
       if (!charCmapInfo) {
-        tachyfont.Cmap.reportError_(
+        tachyfont.Cmap.reportError(
             tachyfont.Cmap.Error.FORMAT12_CHAR_CMAP_INFO,
             weight, 'format 12, code ' + code + ': no CharCmapInfo');
         continue;
@@ -502,31 +501,31 @@ tachyfont.Cmap.setFormat12GlyphIds = function(fileInfo, baseFontView, glyphIds,
       var inMemoryGlyphId = segEd.getUint32();
       // Check the code point.
       if (inMemoryStartCode != segStartCode) {
-        tachyfont.Cmap.reportError_(
+        tachyfont.Cmap.reportError(
             tachyfont.Cmap.Error.FORMAT12_START_CODE,
             weight, 'format 12, code ' + code + ', seg ' + format12Seg +
             ': startCode mismatch');
       }
       if (inMemoryEndCode != segmentEndCode) {
-        tachyfont.Cmap.reportError_(
+        tachyfont.Cmap.reportError(
             tachyfont.Cmap.Error.FORMAT12_END_CODE,
             weight, 'format 12 code ' + code + ', seg ' + format12Seg +
             ': endCode mismatch');
       }
       if (segStartCode != segmentEndCode) { // TODO(bstell): check length
-        tachyfont.Cmap.reportError_(
+        tachyfont.Cmap.reportError(
             tachyfont.Cmap.Error.FORMAT12_SEGMENT_LENGTH,
             weight, 'format 12 code ' + code + ', seg ' + format12Seg +
             ': length != 1');
       }
       if (inMemoryGlyphId != 0) {
         if (inMemoryGlyphId == segStartGlyphId) {
-          tachyfont.Cmap.reportError_(
+          tachyfont.Cmap.reportError(
               tachyfont.Cmap.Error.FORMAT12_GLYPH_ID_ALREADY_SET,
               weight, 'format 12 code ' + code + ', seg ' + format12Seg +
               ' glyphId already set');
         } else {
-          tachyfont.Cmap.reportError_(
+          tachyfont.Cmap.reportError(
               tachyfont.Cmap.Error.FORMAT12_GLYPH_ID_MISMATCH,
               weight, 'format 12 code ' + code + ', seg ' + format12Seg +
               ' glyphId mismatch');

--- a/run_time/src/gae_server/www/js/tachyfont/incrementalfont.js
+++ b/run_time/src/gae_server/www/js/tachyfont/incrementalfont.js
@@ -107,9 +107,8 @@ tachyfont.IncrementalFont.Error = {
  * @param {string} errNum The error number;
  * @param {string} errId Identifies the error.
  * @param {*} errInfo The error object;
- * @private
  */
-tachyfont.IncrementalFont.reportError_ = function(errNum, errId, errInfo) {
+tachyfont.IncrementalFont.reportError = function(errNum, errId, errInfo) {
   if (goog.DEBUG) {
     if (!tachyfont.Reporter.isReady()) {
       goog.log.error(tachyfont.Logger.logger, 'failed to report error');
@@ -189,7 +188,7 @@ tachyfont.IncrementalFont.createManager = function(fontInfo, dropData, params) {
       })
       .thenCatch(function() {
         // Failed to get database;
-        tachyfont.IncrementalFont.reportError_(
+        tachyfont.IncrementalFont.reportError(
             tachyfont.IncrementalFont.Error.OPEN_IDB, weight, 'createManager');
       });
 
@@ -378,7 +377,7 @@ tachyfont.IncrementalFont.obj.prototype.accessDb_ = function(dropDb) {
         if (dropDb) {
           return tachyfont.Persist.deleteDatabase(dbName, weight)
               .thenCatch(function() {
-                tachyfont.IncrementalFont.reportError_(
+                tachyfont.IncrementalFont.reportError(
                     tachyfont.IncrementalFont.Error.DELETE_IDB, weight,
                     'accessDb');
                 return goog.Promise.reject();
@@ -389,7 +388,7 @@ tachyfont.IncrementalFont.obj.prototype.accessDb_ = function(dropDb) {
       .then(function() {
         return tachyfont.Persist.openIndexedDB(dbName, weight)
             .thenCatch(function() {
-              tachyfont.IncrementalFont.reportError_(
+              tachyfont.IncrementalFont.reportError(
                   tachyfont.IncrementalFont.Error.OPEN_IDB, weight,
                   'accessDb');
               return goog.Promise.reject('failed to open IDB');
@@ -429,7 +428,7 @@ tachyfont.IncrementalFont.obj.prototype.getBaseFontFromPersistence =
         if (tachyfont.utils.persistData) {
           filedata = tachyfont.Persist.getData(idb, tachyfont.utils.IDB_BASE)
               .thenCatch(function(e) {
-                tachyfont.IncrementalFont.reportError_(
+                tachyfont.IncrementalFont.reportError(
                  tachyfont.IncrementalFont.Error.GET_DATA,
                  'base ' + this.fontInfo.getWeight(), e);
                 return goog.Promise.reject(e);
@@ -458,7 +457,7 @@ tachyfont.IncrementalFont.obj.prototype.getBaseFontFromPersistence =
               return [arr[1], arr[2], charList];
             },
             function(e) {
-              tachyfont.IncrementalFont.reportError_(
+              tachyfont.IncrementalFont.reportError(
                tachyfont.IncrementalFont.Error.GET_DATA,
                'charList ' + this.fontInfo.getWeight(), e);
               return goog.Promise.reject(e);
@@ -472,7 +471,7 @@ tachyfont.IncrementalFont.obj.prototype.getBaseFontFromPersistence =
           this.charList.resolve(arr[2]);
           return goog.Promise.resolve([arr[0], arr[1], arr[2]]);
         } else {
-          tachyfont.IncrementalFont.reportError_(
+          tachyfont.IncrementalFont.reportError(
               tachyfont.IncrementalFont.Error.NOT_USING_PERSISTED_DATA,
               this.fontInfo.getWeight(), '');
           this.charList.resolve({});
@@ -506,7 +505,7 @@ tachyfont.IncrementalFont.obj.prototype.parseBaseHeader =
   }
   this.fileInfo_ = fileInfo;
   if (!tachyfont.Cmap.isOneCharPerSeg(this.fileInfo_)) {
-    tachyfont.IncrementalFont.reportError_(
+    tachyfont.IncrementalFont.reportError(
         tachyfont.IncrementalFont.Error.CHARS_PER_SEGMENT,
         this.fontInfo.getWeight(), '');
     throw 'not one-char-per-segment';
@@ -883,7 +882,7 @@ tachyfont.IncrementalFont.obj.prototype.loadChars = function() {
       .thenCatch(function(e) {
         // Failed to get the char data so release the lock.
         finishPrecedingCharsRequest.reject('finishPrecedingCharsRequest');
-        tachyfont.IncrementalFont.reportError_(
+        tachyfont.IncrementalFont.reportError(
             tachyfont.IncrementalFont.Error.LOAD_CHARS_GET_LOCK,
             this.fontInfo.getWeight(), e);
         return goog.Promise.resolve(false);
@@ -1024,7 +1023,7 @@ tachyfont.IncrementalFont.obj.prototype.checkFingerprint = function(
  */
 tachyfont.IncrementalFont.obj.prototype.handleFingerprintMismatch =
     function() {
-  tachyfont.IncrementalFont.reportError_(
+  tachyfont.IncrementalFont.reportError(
       tachyfont.IncrementalFont.Error.FINGERPRINT_MISMATCH,
       this.fontInfo.getWeight(), '');
 
@@ -1077,7 +1076,7 @@ tachyfont.IncrementalFont.obj.prototype.injectChars = function(neededCodes,
           var missingCodes = Object.keys(glyphToCodeMap);
           if (missingCodes.length != 0) {
             missingCodes = missingCodes.slice(0, 5);
-            tachyfont.IncrementalFont.reportError_(
+            tachyfont.IncrementalFont.reportError(
                tachyfont.IncrementalFont.Error.LOAD_CHARS_INJECT_CHARS_2,
                this.fontInfo.getWeight(), missingCodes.toString());
           }
@@ -1197,7 +1196,7 @@ tachyfont.IncrementalFont.obj.prototype.persist_ = function(name) {
                    return tachyfont.Persist.saveData(arr[0],
                    tachyfont.utils.IDB_BASE, arr[2].buffer)
                    .thenCatch(function(e) {
-                     tachyfont.IncrementalFont.reportError_(
+                     tachyfont.IncrementalFont.reportError(
                      tachyfont.IncrementalFont.Error.SAVE_DATA,
                      'base ' + that.fontInfo.getWeight(), e);
                    });
@@ -1218,7 +1217,7 @@ tachyfont.IncrementalFont.obj.prototype.persist_ = function(name) {
                    return tachyfont.Persist.saveData(arr[0],
                    tachyfont.utils.IDB_CHARLIST, arr[1])
                    .thenCatch(function(e) {
-                     tachyfont.IncrementalFont.reportError_(
+                     tachyfont.IncrementalFont.reportError(
                      tachyfont.IncrementalFont.Error.SAVE_DATA,
                      'charList ' + that.fontInfo.getWeight(), e);
                    });
@@ -1226,7 +1225,7 @@ tachyfont.IncrementalFont.obj.prototype.persist_ = function(name) {
               }
             })
             .thenCatch(function(e) {
-              tachyfont.IncrementalFont.reportError_(
+              tachyfont.IncrementalFont.reportError(
                   tachyfont.IncrementalFont.Error.PERSIST_SAVE_DATA,
                   that.fontInfo.getWeight(), e);
             })
@@ -1239,7 +1238,7 @@ tachyfont.IncrementalFont.obj.prototype.persist_ = function(name) {
               }
             });
       }).thenCatch(function(e) {
-        tachyfont.IncrementalFont.reportError_(
+        tachyfont.IncrementalFont.reportError(
             tachyfont.IncrementalFont.Error.PERSIST_GET_LOCK,
             that.fontInfo.getWeight(), e);
         // Release the lock.

--- a/run_time/src/gae_server/www/js/tachyfont/persist_idb.js
+++ b/run_time/src/gae_server/www/js/tachyfont/persist_idb.js
@@ -47,9 +47,8 @@ tachyfont.Persist.Error = {
  * @param {string} errNum The error number;
  * @param {string} errId Identifies the error.
  * @param {*} errInfo The error object;
- * @private
  */
-tachyfont.Persist.reportError_ = function(errNum, errId, errInfo) {
+tachyfont.Persist.reportError = function(errNum, errId, errInfo) {
   if (goog.DEBUG) {
     if (!tachyfont.Reporter.isReady()) {
       goog.log.error(tachyfont.Logger.logger, 'failed to report error');
@@ -100,7 +99,7 @@ tachyfont.Persist.openIndexedDB = function(dbName, id) {
       resolve(db);
     };
     dbOpen.onerror = function(e) {
-      tachyfont.Persist.reportError_(tachyfont.Persist.Error.OPEN_IDB,
+      tachyfont.Persist.reportError(tachyfont.Persist.Error.OPEN_IDB,
           id, '!!! openIndexedDB "' + dbName);
       reject();
     };
@@ -109,7 +108,7 @@ tachyfont.Persist.openIndexedDB = function(dbName, id) {
     dbOpen.onupgradeneeded = function(e) {
       var db = e.target.result;
       e.target.transaction.onerror = function(e) {
-        tachyfont.Persist.reportError_(
+        tachyfont.Persist.reportError(
             tachyfont.Persist.Error.IDB_ON_UPGRAGE_NEEDED,
             id, 'onupgradeneeded error: ' + e.value);
         reject();
@@ -139,19 +138,19 @@ tachyfont.Persist.deleteDatabase = function(dbName, id) {
     var req = window.indexedDB.deleteDatabase(dbName);
     req.onsuccess = function() {
       // If the user cleared the data something may be wrong.
-      tachyfont.Persist.reportError_(
+      tachyfont.Persist.reportError(
           tachyfont.Persist.Error.DELETED_DATA, id,
           'Deleted database successfully');
       resolve();
     };
     req.onerror = function() {
-      tachyfont.Persist.reportError_(
+      tachyfont.Persist.reportError(
           tachyfont.Persist.Error.DELETE_DATA_FAILED, id,
           'Delete database failed');
       reject(1);
     };
     req.onblocked = function() {
-      tachyfont.Persist.reportError_(
+      tachyfont.Persist.reportError(
           tachyfont.Persist.Error.DELETE_DATA_BLOCKED, id,
           'Delete database blocked');
       reject(2);


### PR DESCRIPTION
check storage font by font.

Only report "not enough storage" once (not once per font).