### PR TITLE
Add a global check for stable persistent store.

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/incrementalfont.js
+++ b/run_time/src/gae_server/www/js/tachyfont/incrementalfont.js
@@ -291,7 +291,7 @@ tachyfont.IncrementalFont.obj = function(fontInfo, params, backendService) {
    * True if new characters have been loaded since last setFont
    * @type {boolean}
    */
-  this.needToSetFont = false;
+  this.needToSetFont = true;
 
   this.url = fontInfo.getDataUrl();
   this.charsURL = '/incremental_fonts/request';


### PR DESCRIPTION
On first page load set the font.  
If Prelude already set the font then this is not necessary but if there
is any issue with Prelude then this is a safety move.

Add a global check for stable persistent store.
Reorder the initialization code so the Prelude reports get sent earlier.