### PR TITLE
Move the cmap parsing into the base font header parsing.

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/typedefs.js
+++ b/run_time/src/gae_server/www/js/tachyfont/typedefs.js
@@ -68,10 +68,11 @@ tachyfont.typedef.charset;
  *     hmetricCount: number,
  *     vmetricCount: number,
  *     isTtf: number,
- *     cmap12: tachyfont.typedef.CMap12,
- *     cmap4: tachyfont.typedef.CMap4,
- *     compact_gos: tachyfont.typedef.compact_gos,
- *     charset_fmt: tachyfont.typedef.charset,
+ *     cmap12: !tachyfont.typedef.CMap12,
+ *     cmap4: !tachyfont.typedef.CMap4,
+ *     compact_gos: !tachyfont.typedef.compact_gos,
+ *     cmapMapping: !tachyfont.typedef.CmapMapping,
+ *     charset_fmt: !tachyfont.typedef.charset,
  *     sha1_fingerprint: string
  * }}
  */


### PR DESCRIPTION
Move the base font header parsing completely into BinaryFontEditor.