### PR TITLE
Add code to load/fetch the Compact TachyFont (disabled behind a debug

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/typedefs.js
+++ b/run_time/src/gae_server/www/js/tachyfont/typedefs.js
@@ -25,6 +25,7 @@ goog.provide('tachyfont.typedef');
 goog.provide('tachyfont.typedef.CMap12');
 goog.provide('tachyfont.typedef.CMap4');
 goog.provide('tachyfont.typedef.CmapMapping');
+goog.provide('tachyfont.typedef.CompactFontWorkingData');
 goog.provide('tachyfont.typedef.FileInfo');
 goog.provide('tachyfont.typedef.uint8');
 
@@ -39,6 +40,16 @@ tachyfont.typedef.CMap4;
 
 /** @typedef {!Object<number, !tachyfont.CharCmapInfo>} */
 tachyfont.typedef.CmapMapping;
+
+
+/**
+ * @typedef {{
+ *     data: !DataView,
+ *     charList: !Object<number, number>,
+ *     fileInfo: !tachyfont.typedef.FileInfo
+ * }}
+ */
+tachyfont.typedef.CompactFontWorkingData;
 
 
 /**


### PR DESCRIPTION
only URL parameter).
Add code to fetch Compact TachyFont from a URL (work in progress).
Add code to fetch Compact TachyFont from persistence.
Make tachyfont.IncrementalFont.Log public so it can be used in tests.