### PR TITLE
Make injectChars a simple subroutine by moving the promise code into the caller.

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/compactcff.js
+++ b/run_time/src/gae_server/www/js/tachyfont/compactcff.js
@@ -224,7 +224,7 @@ tachyfont.CompactCff.prototype.addDataSegment = function(
  * @param {!Object<number,!Array<number>>} glyphToCodeMap The map of glyph id to
  *     codepoints.
  * @param {!tachyfont.GlyphBundleResponse} bundleResponse New glyph data
- * @return {!goog.Promise<!DataView,?>} A promise for the new font data bytes.
+ * @return {!goog.Promise<!tachyfont.CompactCff,?>} A promise for CompactCff.
  *
  */
 tachyfont.CompactCff.injectChars = function(
@@ -237,7 +237,7 @@ tachyfont.CompactCff.injectChars = function(
       .then(function(db) {
         // Create the transaction.
         transaction =
-            db.transaction(tachyfont.Define.compactStoreNames, 'readonly');
+            db.transaction(tachyfont.Define.compactStoreNames, 'readwrite');
         // Get the persisted data.
         return compactCff.readDbTables(transaction);
       })
@@ -246,8 +246,8 @@ tachyfont.CompactCff.injectChars = function(
         // Write the persisted data.
         return compactCff.writeDbTables(transaction);
       })
-      .then(function(something) {
-        return compactCff.getSfnt().getFontData();  //
+      .then(function() {
+        return compactCff;  //
       });
 };
 

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfont.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfont.js
@@ -551,9 +551,11 @@ tachyfont.loadFonts_loadAndUse_ = function(tachyFontSet) {
                   var incrfont = fonts[index].incrfont;
                   // Load the fonts from persistent store or URL.
                   return tachyfont.loadFonts_getBaseFont_(incrfont)
-                      .then(function() {
+                      .then(function(baseFont) {
                         if (goog.DEBUG) {
+                          var fileInfo = baseFont[0];
                           if (tachyfont.Define.compactTachyFont &&
+                              !fileInfo.isTtf &&
                               incrfont.getShouldBeCompact()) {
                             return incrfont.getCompactFont();
                           }
@@ -670,6 +672,7 @@ tachyfont.loadFonts_getBaseFont_ = function(incrfont) {
       .then(function(loadedBase) {
         // Get the font data ready for use.
         incrfont.base.resolve(loadedBase);
+        return loadedBase;
       });
 };
 


### PR DESCRIPTION
Separate the glyphIdToCodeMap logic into a subroutine.