### PR TITLE
Make injectChars a simple subroutine by moving the promise code into the caller.

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/backendservice.js
+++ b/run_time/src/gae_server/www/js/tachyfont/backendservice.js
@@ -135,7 +135,6 @@ BackendService.prototype.log = goog.functions.NULL;
  * @param {?string} postData Request data
  * @param {?Object} headers Request headers
  * @return {!goog.Promise} Promise to return response
- * @protected
  */
 BackendService.prototype.requestUrl = function(url, method, postData,
     headers) {


### PR DESCRIPTION
Separate the glyphIdToCodeMap logic into a subroutine.