### PR TITLE
Until Compact TachyFont is fully enabled use an alternate @font-face …

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/incrementalfont.js
+++ b/run_time/src/gae_server/www/js/tachyfont/incrementalfont.js
@@ -27,6 +27,7 @@ goog.require('tachyfont.Cmap');
 goog.require('tachyfont.CompactCff');
 goog.require('tachyfont.Define');
 goog.require('tachyfont.DemoBackendService');
+goog.require('tachyfont.FontInfo');
 goog.require('tachyfont.GoogleBackendService');
 goog.require('tachyfont.IncrementalFontUtils');
 goog.require('tachyfont.Metadata');
@@ -1095,8 +1096,14 @@ tachyfont.IncrementalFont.obj.prototype.injectCompact = function(
       .then(function(compactCff) {
         var fontData = compactCff.getSfnt().getFontData();
         var fileInfo = compactCff.getFileInfo();
+        // Until Compact TachyFont is fully enabled make an alternate fontInfo
+        // with a different fontFamily name.
+        // TODO(bstell): use the real fontInfo.
+        var compactFontInfo = new tachyfont.FontInfo(
+            this.fontInfo.getName() + '-Compact', this.fontInfo.getWeight(),
+            this.fontInfo.getPriority());
         return tachyfont.Browser
-            .setFont(fontData, this.fontInfo, fileInfo.isTtf, null)
+            .setFont(fontData, compactFontInfo, fileInfo.isTtf, null)
             .then(function() {
               // This is a success report sent via the error reporting system.
               tachyfont.IncrementalFont.reportError(

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfontreporter.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfontreporter.js
@@ -226,7 +226,7 @@ tachyfont.Reporter.sendReport = function() {
 tachyfont.Reporter.sendGen204_ = function(baseUrl, params) {
   var reportUrl = baseUrl + params.join('&');
   if (goog.DEBUG) {
-    tachyfont.log.info('send: ' + params.join(', '));
+    tachyfont.log.info('report: ' + params.join(', '));
   }
   var image = new Image();
   image.onload = image.onerror = tachyfont.Reporter.cleanUpFunc_(image);


### PR DESCRIPTION
…family-name to avoid disturbing use of the regular TachyFont.