### PR TITLE
Run the Compact TachyFont code for the 500 weight. This runs the new …

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/incrementalfont.js
+++ b/run_time/src/gae_server/www/js/tachyfont/incrementalfont.js
@@ -284,7 +284,7 @@ tachyfont.IncrementalFont.obj = function(fontInfo, params, backendService) {
   // TODO(bstell): remove this when Compact TachyFont is fully enabled.
   // The font weights are: 100, 300, 400, 500, 700.
   // This enables Compact TachyFont for weights greater than the number.
-  this.shouldBeCompact_ = parseInt(weight, 10) > 650;
+  this.shouldBeCompact_ = parseInt(weight, 10) > 450;
 
   /**
    * Whether the font is compacted.
@@ -1228,9 +1228,6 @@ tachyfont.IncrementalFont.obj.prototype.loadChars = function() {
                             .getCompactFontFromUrl(
                                 this.backendService, this.fontInfo)
                             .then(function(compactWorkingData) {
-                              // Replace the previous compact charlist.
-                              this.compactCharList_ =
-                                  new tachyfont.Promise.Encapsulated();
                               this.compactCharList_.resolve(
                                   compactWorkingData.charList);
                             }.bind(this))

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfontpromise.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfontpromise.js
@@ -31,7 +31,7 @@ goog.require('tachyfont.log');
  * @param {!tachyfont.Promise.Chained=} opt_container If used to chain promises
  *     then this holds the object that implements the chaining.
  * @param {string=} opt_msg An optional message useful for debugging.
- * @constructor
+ * @constructor @final @struct
  */
 tachyfont.Promise.Encapsulated = function(opt_container, opt_msg) {
   var resolver;
@@ -98,7 +98,7 @@ tachyfont.Promise.Encapsulated.Error_ = {
 
 
 /**
- * The error reporter for this file.
+ * Reports errors for this file.
  * @param {string} errNum The error number;
  * @param {*} errInfo The error object;
  * @private


### PR DESCRIPTION
…code far more often than the 700 weight.

Do not replace the Encapsulated charList (this is properly hanlded internally by the class).