### PR TITLE
Use .thenAlways to release ChainedPromises.

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/persist_idb.js
+++ b/run_time/src/gae_server/www/js/tachyfont/persist_idb.js
@@ -45,8 +45,7 @@ tachyfont.Persist.Error = {
   SAVE_BEGIN_AFTER_CREATED_METADATA: '11',
   IDB_GLOBAL_OPEN: '12',
   IDB_GLOBAL_ON_UPGRAGE_NEEDED: '13',
-  CREATE_COMPACT_DATA_BEGIN: '14',
-  CREATE_COMPACT_DATA_DONE: '15',
+  // 14-15 no longer used.
   GET_STORE: '16',
   PUT_STORE: '17',
   END_VALUE: '00'
@@ -159,8 +158,6 @@ tachyfont.Persist.openIndexedDb_ = function(dbName, id, resolve, reject) {
       tachyfont.Metadata.initializePerFont(metadataStore);
     }
     // Compact TachyFont data.
-    tachyfont.Persist.reportError(
-        tachyfont.Persist.Error.CREATE_COMPACT_DATA_BEGIN, id, '');
     if (!db.objectStoreNames.contains(tachyfont.Define.COMPACT_FONT)) {
       db.createObjectStore(tachyfont.Define.COMPACT_FONT);
     }
@@ -179,8 +176,6 @@ tachyfont.Persist.openIndexedDb_ = function(dbName, id, resolve, reject) {
           db.createObjectStore(tachyfont.Define.COMPACT_CHAR_LIST);
       tachyfont.Persist.initializeCharList(compactCharsListStore);
     }
-    tachyfont.Persist.reportError(
-        tachyfont.Persist.Error.CREATE_COMPACT_DATA_DONE, id, '');
   };
 };
 

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfontpromise.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfontpromise.js
@@ -27,7 +27,6 @@ goog.require('tachyfont.log');
 
 /**
  * A class that holds a promise and the associated resolve and reject functions.
- *
  * @param {!tachyfont.Promise.Chained=} opt_container If used to chain promises
  *     then this holds the object that implements the chaining.
  * @param {string=} opt_msg An optional message useful for debugging.

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfontset.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfontset.js
@@ -108,7 +108,7 @@ tachyfont.TachyFontSet.Log = {
 tachyfont.TachyFontSet.Error = {
   FILE_ID: 'ETS',
   UPDATE_FONT_LOAD_CHARS: '01',
-  UPDATE_FONT_SET_FONT: '02',
+  // 02 no longer used.
   SET_FONT: '03'
 };
 


### PR DESCRIPTION
Remove an unneeded promise layer in tachyfont.loadFonts_loadAndUse_.
Remove some 'error' reports used to report successes.
Minor cleanups