### PR TITLE
Beginning to decouple FileInfo from IncrementalFont.

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/cmap.js
+++ b/run_time/src/gae_server/www/js/tachyfont/cmap.js
@@ -322,7 +322,7 @@ tachyfont.Cmap.checkCharacters = function(
  * @param {!tachyfont.typedef.FileInfo} fileInfo Info about the font file.
  * @param {!DataView} baseFontView Current base font
  * @param {!Array<number>} glyphIds The glyph Ids to set.
- * @param {!Object<number, Array<number>>} glyphToCodeMap The glyph Id to code
+ * @param {!Object<number, !Array<number>>} glyphToCodeMap The glyph Id to code
  *     point mapping;
  * @param {string} fontId The fontId for error reporting.
  */
@@ -429,7 +429,7 @@ tachyfont.Cmap.setFormat4GlyphIds = function(
  * @param {!tachyfont.typedef.FileInfo} fileInfo Info about the font file.
  * @param {!DataView} baseFontView Current base font
  * @param {!Array<number>} glyphIds The glyph Ids to set.
- * @param {!Object<number, Array<number>>} glyphToCodeMap The glyph Id to code
+ * @param {!Object<number, !Array<number>>} glyphToCodeMap The glyph Id to code
  *     point mapping;
  * @param {string} fontId The fontId of the font.
  */

--- a/run_time/src/gae_server/www/js/tachyfont/incrementalfont.js
+++ b/run_time/src/gae_server/www/js/tachyfont/incrementalfont.js
@@ -1063,7 +1063,8 @@ tachyfont.IncrementalFont.obj.prototype.loadChars = function() {
  */
 tachyfont.IncrementalFont.obj.prototype.injectCompact = function(
     neededCodes, bundleResponse) {
-  var glyphToCodeMap = this.getGlyphToCodeMap(neededCodes);
+  var glyphToCodeMap = tachyfont.IncrementalFontUtils.getGlyphToCodeMap(
+      neededCodes, this.fileInfo_.cmapMapping);
   return tachyfont.CompactCff
       .injectChars(this.fontInfo_, neededCodes, glyphToCodeMap, bundleResponse)
       .thenCatch(function(e) {
@@ -1239,34 +1240,6 @@ tachyfont.IncrementalFont.obj.prototype.handleFingerprintMismatch = function() {
       .then(function(db) {
              return goog.Promise.reject('deleted database');
       }.bind(this));
-};
-
-
-/**
- * Inject glyph data and enable the chars in the cmaps.
- * @param {!Array<number>} neededCodes The codes to be injected.
- * @return {!Object<number,!Array<number>>}
- */
-tachyfont.IncrementalFont.obj.prototype.getGlyphToCodeMap = function(
-    neededCodes) {
-  var glyphToCodeMap = {};
-  for (var i = 0; i < neededCodes.length; i++) {
-    var code = neededCodes[i];
-    var charCmapInfo = this.fileInfo_.cmapMapping[code];
-    if (charCmapInfo) {
-      // Handle multiple codes sharing a glyphId.
-      if (glyphToCodeMap[charCmapInfo.glyphId] == undefined) {
-        glyphToCodeMap[charCmapInfo.glyphId] = [];
-      }
-      glyphToCodeMap[charCmapInfo.glyphId].push(code);
-    }
-    if (goog.DEBUG) {
-      if (!charCmapInfo) {
-        tachyfont.log.warning('no glyph for codepoint 0x' + code.toString(16));
-      }
-    }
-  }
-  return glyphToCodeMap;
 };
 
 

--- a/run_time/src/gae_server/www/js/tachyfont/incrementalfontutils.js
+++ b/run_time/src/gae_server/www/js/tachyfont/incrementalfontutils.js
@@ -50,6 +50,35 @@ tachyfont.IncrementalFontUtils.STYLESHEET_ID =
 
 
 /**
+ * Gets the map of glyphIds to codepoints.
+ * @param {!Array<number>} neededCodes The codes to be injected.
+ * @param {!tachyfont.typedef.CmapMapping} cmapMapping The cmap info.
+ * @return {!Object<number,!Array<number>>}
+ */
+tachyfont.IncrementalFontUtils.getGlyphToCodeMap = function(
+    neededCodes, cmapMapping) {
+  var glyphToCodeMap = {};
+  for (var i = 0; i < neededCodes.length; i++) {
+    var code = neededCodes[i];
+    var charCmapInfo = cmapMapping[code];
+    if (charCmapInfo) {
+      // Handle multiple codes sharing a glyphId.
+      if (glyphToCodeMap[charCmapInfo.glyphId] == undefined) {
+        glyphToCodeMap[charCmapInfo.glyphId] = [];
+      }
+      glyphToCodeMap[charCmapInfo.glyphId].push(code);
+    }
+    if (goog.DEBUG) {
+      if (!charCmapInfo) {
+        tachyfont.log.warning('no glyph for codepoint 0x' + code.toString(16));
+      }
+    }
+  }
+  return glyphToCodeMap;
+};
+
+
+/**
  * Set the Horizontal/Vertical metrics.
  * @param {number} flags Indicates what is in the glyphData.
  * @param {!tachyfont.GlyphBundleResponse.GlyphData} glyphData An object holding

--- a/run_time/src/gae_server/www/js/tachyfont/typedefs.js
+++ b/run_time/src/gae_server/www/js/tachyfont/typedefs.js
@@ -62,7 +62,7 @@ tachyfont.typedef.Resolver;
 
 
 /**
- * @typedef {Object}
+ * @typedef {!Object}
  */
 tachyfont.typedef.Context;
 


### PR DESCRIPTION
- FileInfo is only used during character data injection.
- FileInfo holds ~4MB memory so only bring it into memory during injection.
- Move getGlyphToCodeMap into incrementalfontutils.js

Set explicit non-nullability in various places.