### PR TITLE
Slowly re-removing the code for the alternateBitInfo.

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/sparse_bit_array.js
+++ b/run_time/src/gae_server/www/js/tachyfont/sparse_bit_array.js
@@ -125,8 +125,6 @@ SparseBitArray.prototype.isSet = function(index) {
   var pageIndex = index >> SparseBitArray.PAGE_SHIFT;
   var pageBitArray = this.pages_[pageIndex];
   if (!pageBitArray) {
-    goog.asserts.assert(
-        !this.alternateBitInfo_[index], 'bit %s should not be set', index);
     return false;
   }
   var pageBitIndex = index & SparseBitArray.PAGE_MASK;


### PR DESCRIPTION
It was removed but then rolled back due to a 4% increase in CALC_NEEDED_CHARS.