### PR TITLE
Process the merged fontbases (will be used once the XDelta3 decoder i…

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/tachyfont.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfont.js
@@ -493,6 +493,7 @@ tachyfont.isFontStored = function(dbName) {
           objectStoreNames.contains(tachyfont.Define.COMPACT_FILE_INFO) &&
           objectStoreNames.contains(tachyfont.Define.COMPACT_CHAR_LIST) &&
           objectStoreNames.contains(tachyfont.Define.COMPACT_METADATA);
+      db.close();
       resolve(isStored);
     };
     request.onerror = function(e) {


### PR DESCRIPTION
…s available)

In merged_data.js have getData ArrayBuffer instead Uint8Array to eliminate byteOffset.
Also change the version, change the magic number, change the primary tag, pass in the family name.
In tachyfont.js close the db after checking if the font is stored.