### PR TITLE
In incrementalfont.js use PreludeInfo to get the prelude data.

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/fontinfo.js
+++ b/run_time/src/gae_server/www/js/tachyfont/fontinfo.js
@@ -216,3 +216,4 @@ tachyfont.FontInfo.prototype.getFontId = function() {
   return this.weight_;
 };
 
+goog.exportSymbol('tachyfont.FontInfo', tachyfont.FontInfo);

--- a/run_time/src/gae_server/www/js/tachyfont/prelude_info.js
+++ b/run_time/src/gae_server/www/js/tachyfont/prelude_info.js
@@ -2,7 +2,7 @@
 
 /**
  * @license
- * Copyright 2015 Google Inc. All rights reserved.
+ * Copyright 2017 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -45,6 +45,11 @@ tachyfont.PreludeInfo = function() {
    */
   this.startTime_ = this.tachyfontprelude['startTime'] || Date.now();
 
+  /**
+   * The font Blob URLs.
+   * @private {!Object<(string|undefined), string>}
+   */
+  this.urls_ = this.tachyfontprelude['urls'] || {};
 };
 
 
@@ -87,11 +92,23 @@ tachyfont.PreludeInfo.prototype.getStartTime = function() {
 
 /**
  * Gets the merged fontbase data (promise) if available.
- * @return {?Promise<Uint8Array>}
+ * @return {!Promise<?Uint8Array>}
  */
 tachyfont.PreludeInfo.prototype.getMergedFontbasesBytes = function() {
-  var tachyfont_loader = window['tachyfont_loader'] || {};
-  return tachyfont_loader['mergedFontBases'] || null;
+  return this.tachyfontprelude['mergedFontBases'] ||
+      new Promise(function(resolve) {
+           resolve(null);
+         });
+};
+
+
+/**
+ * Gets the font Blob URLs.
+ * @param {string} fontId The font identifier.
+ * @return {?string}
+ */
+tachyfont.PreludeInfo.prototype.getUrl = function(fontId) {
+  return this.urls_[fontId] || null;
 };
 
 

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfont.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfont.js
@@ -213,13 +213,13 @@ tachyfont.reportError = function(errNum, opt_errInfo, opt_fontId) {
 
 /**
  * Load a list of TachyFonts
- * @param {string} familyName The font-family name.
+ * @param {string} cssFamilyName The font-family name.
  * @param {!tachyfont.FontsInfo} fontsInfo Information about the fonts.
  * @param {!Object<string, string>=} opt_params Optional parameters.
  * @return {!goog.Promise<?tachyfont.TachyFontSet,?>} A promise that returns the
  *     TachyFontSet object or null if the fonts are not loaded.
  */
-tachyfont.loadFonts = function(familyName, fontsInfo, opt_params) {
+tachyfont.loadFonts = function(cssFamilyName, fontsInfo, opt_params) {
   if (goog.DEBUG) {
     tachyfont.debugInitialization_();
   }
@@ -242,7 +242,7 @@ tachyfont.loadFonts = function(familyName, fontsInfo, opt_params) {
       .then(function(mergedFontbasesBytes) {
         // Initialize the objects.
         var tachyFontSet =
-            tachyfont.loadFonts_init_(familyName, fontsInfo, opt_params);
+            tachyfont.loadFonts_init_(cssFamilyName, fontsInfo, opt_params);
         // Load the fonts.
         var xdelta3Decoder = preludeInfo.getXDeltaDecoder();
         var fontbases =


### PR DESCRIPTION
Export the FontInfo constructor so prelude will be able to use it.
To ease testing make the prelude tests closure files.
Remove the placeholder_test_data.js as it is no longer used.