### PR TITLE
Variable renaming. No functional changes.

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/browser_chrome.js
+++ b/run_time/src/gae_server/www/js/tachyfont/browser_chrome.js
@@ -79,10 +79,10 @@ tachyfont.Browser.setFont = function(fontData, fontInfo, isTtf, oldBlobUrl) {
 // browsers.
 tachyfont.Browser.setFontNoFlash = function(fontInfo, format, blobUrl) {
   // The desired @font-face font-family.
-  var fontFamily = fontInfo.getFamilyName();
+  var cssFontFamily = fontInfo.getCssFontFamily();
   // The temporary @font-face font-family.
   var weight = fontInfo.getWeight();
-  var tmpFontFamily = 'tmp-' + weight + '-' + fontFamily;
+  var tmpFontFamily = 'tmp-' + weight + '-' + cssFontFamily;
   var sheet = tachyfont.IncrementalFontUtils.getStyleSheet();
 
   // Create a temporary @font-face rule to transfer the blobUrl data from
@@ -110,7 +110,7 @@ tachyfont.Browser.setFontNoFlash = function(fontInfo, format, blobUrl) {
           .then(function() {
             // The font is ready so switch the @font-face to the desired name.
             tachyfont.Browser.switchFont(
-                sheet, tmpFontFamily, fontFamily, weight, blobUrl, format);
+                sheet, tmpFontFamily, cssFontFamily, weight, blobUrl, format);
           });
 
   return setFontPromise;
@@ -123,16 +123,16 @@ tachyfont.Browser.setFontNoFlash = function(fontInfo, format, blobUrl) {
  * @param {!CSSStyleSheet} sheet The CSS style sheet.
  * @param {string} tmpFontFamily The temporary font-family that is loading the
  *     blob.
- * @param {string} fontFamily The target font-family.
+ * @param {string} cssFontFamily The target font-family.
  * @param {string} weight The The target weight
  * @param {string} blobUrl The blob URL for the font data.
  * @param {string} format The font type.
  */
-tachyfont.Browser.switchFont = function(sheet, tmpFontFamily, fontFamily,
-    weight, blobUrl, format) {
+tachyfont.Browser.switchFont = function(
+    sheet, tmpFontFamily, cssFontFamily, weight, blobUrl, format) {
   // Set the updated font rule.
-  tachyfont.IncrementalFontUtils.setCssFontRule(sheet, fontFamily, weight,
-      blobUrl, format);
+  tachyfont.IncrementalFontUtils.setCssFontRule(
+      sheet, cssFontFamily, weight, blobUrl, format);
 
   // Delete the temporary rule
   var ruleToDelete = tachyfont.IncrementalFontUtils.findFontFaceRule(
@@ -140,9 +140,7 @@ tachyfont.Browser.switchFont = function(sheet, tmpFontFamily, fontFamily,
   if (goog.DEBUG) {
     tachyfont.log.info(
         '**** switched ' + weight + ' from ' + tmpFontFamily + ' to ' +
-        fontFamily + ' ****');
+        cssFontFamily + ' ****');
   }
   tachyfont.IncrementalFontUtils.deleteCssRule(ruleToDelete, sheet);
 };
-
-

--- a/run_time/src/gae_server/www/js/tachyfont/demobackendservice.js
+++ b/run_time/src/gae_server/www/js/tachyfont/demobackendservice.js
@@ -43,8 +43,8 @@ var DemoBackendService = tachyfont.DemoBackendService;
 /** @override */
 DemoBackendService.prototype.requestCodepoints = function(fontInfo, codes) {
   var that = this;
-  var params = 'fontName=' + fontInfo.getName() + '&weight=' +
-      fontInfo.getWeight() + '&codepoints=' + codes.join(',');
+  var params = 'fontName=' + fontInfo.getFontFamily() +
+      '&weight=' + fontInfo.getWeight() + '&codepoints=' + codes.join(',');
   return this
       .requestUrl(
           this.baseUrl + '/characterdata', 'POST', params,
@@ -57,7 +57,8 @@ DemoBackendService.prototype.requestCodepoints = function(fontInfo, codes) {
 
 /** @override */
 DemoBackendService.prototype.requestFontBase = function(fontInfo) {
-  var url = this.baseUrl + '/fontbase?fontname=' + fontInfo.getName() + '&' +
+  var url = this.baseUrl + '/fontbase?fontname=' + fontInfo.getFontFamily() +
+      '&' +
       'weight=' + fontInfo.getWeight();
   return this.requestUrl(url, 'GET', null, {});
 };

--- a/run_time/src/gae_server/www/js/tachyfont/fontinfo.js
+++ b/run_time/src/gae_server/www/js/tachyfont/fontinfo.js
@@ -25,7 +25,7 @@ goog.require('tachyfont.Define');
 
 /**
  * The information for a font.
- * @param {?string} name The font name.
+ * @param {?string} fontFamily The font family name.
  * @param {?string} weight The font weight.
  * @param {boolean} priority Indicates whether this font should be
  *     prioritized over other fonts.
@@ -36,11 +36,11 @@ goog.require('tachyfont.Define');
  * @constructor
  */
 tachyfont.FontInfo = function(
-    name, weight, priority, opt_familyPath, opt_version, opt_fontKit,
+    fontFamily, weight, priority, opt_familyPath, opt_version, opt_fontKit,
     opt_size) {
 
   /** @private @const {string} */
-  this.name_ = name || '';
+  this.fontFamily_ = fontFamily || '';
 
   /** @private @const {string} */
   this.weight_ = weight || '';
@@ -74,7 +74,7 @@ tachyfont.FontInfo = function(
   this.size_ = opt_size || 5 * 1000 * 1000;
 
   /** @private {string} */
-  this.familyName_ = '';
+  this.cssFontFamily_ = '';
 
   /** @private {string} */
   this.dataUrl_ = '';
@@ -82,11 +82,11 @@ tachyfont.FontInfo = function(
 
 
 /**
- * Gets the name of the TachyFont.
- * @return {string} The name of the TachyFont.
+ * Gets the font family name of the TachyFont.
+ * @return {string}
  */
-tachyfont.FontInfo.prototype.getName = function() {
-  return this.name_;
+tachyfont.FontInfo.prototype.getFontFamily = function() {
+  return this.fontFamily_;
 };
 
 
@@ -136,20 +136,20 @@ tachyfont.FontInfo.prototype.getSize = function() {
 
 
 /**
- * Gets the family name of the TachyFont.
- * @return {string} The family name of the TachyFont.
+ * Gets the css font family name of the TachyFont.
+ * @return {string}
  */
-tachyfont.FontInfo.prototype.getFamilyName = function() {
-  return this.familyName_;
+tachyfont.FontInfo.prototype.getCssFontFamily = function() {
+  return this.cssFontFamily_;
 };
 
 
 /**
- * Sets the family name of the TachyFont.
- * @param {string} familyName The family name of the TachyFont.
+ * Sets the css font family name of the TachyFont.
+ * @param {string} cssFontFamily The css font family name of the TachyFont.
  */
-tachyfont.FontInfo.prototype.setFamilyName = function(familyName) {
-  this.familyName_ = familyName;
+tachyfont.FontInfo.prototype.setCssFontFamily = function(cssFontFamily) {
+  this.cssFontFamily_ = cssFontFamily;
 };
 
 
@@ -203,7 +203,8 @@ tachyfont.FontInfo.prototype.setShouldLoad = function(setting) {
  * @return {string} The database name.
  */
 tachyfont.FontInfo.prototype.getDbName = function() {
-  return tachyfont.Define.DB_NAME + '/' + this.name_ + '/' + this.getFontId();
+  return tachyfont.Define.DB_NAME + '/' + this.fontFamily_ + '/' +
+      this.getFontId();
 };
 
 

--- a/run_time/src/gae_server/www/js/tachyfont/googlebackendservice.js
+++ b/run_time/src/gae_server/www/js/tachyfont/googlebackendservice.js
@@ -107,8 +107,8 @@ GoogleBackendService.prototype.getDataUrl =
     function(fontInfo, prefix, suffix) {
   var familyPath = fontInfo.getFamilyPath();
   if (!familyPath) {
-    // Using familyPath is preferred over familyName.
-    familyPath = fontInfo.getFamilyName().replace(/ /g, '').toLowerCase();
+    // Using familyPath is preferred over cssFontFamily.
+    familyPath = fontInfo.getCssFontFamily().replace(/ /g, '').toLowerCase();
   }
   return this.baseUrl + '/' + prefix + '/' +
       'p' + tachyfont.BackendService.PROTOCOL_MAJOR_VERSION +

--- a/run_time/src/gae_server/www/js/tachyfont/incrementalfont.js
+++ b/run_time/src/gae_server/www/js/tachyfont/incrementalfont.js
@@ -268,8 +268,8 @@ tachyfont.IncrementalFont.obj.prototype.getFontInfo = function() {
  * Gets the font name.
  * @return {string}
  */
-tachyfont.IncrementalFont.obj.prototype.getFontName = function() {
-  return this.fontInfo_.getName();
+tachyfont.IncrementalFont.obj.prototype.getFontFamily = function() {
+  return this.fontInfo_.getFontFamily();
 };
 
 
@@ -625,7 +625,7 @@ tachyfont.IncrementalFont.processUrlBase = function(
  * @return {!goog.Promise} The promise resolves when the glyphs are displaying.
  */
 tachyfont.IncrementalFont.obj.prototype.setFont = function(fontData) {
-  var msg = this.fontInfo_.getName() + ' setFont.' + this.fontId_;
+  var msg = this.fontInfo_.getFontFamily() + ' setFont.' + this.fontId_;
   var finishPrecedingSetFont =
       this.finishPrecedingSetFont_.getChainedPromise(msg);
   return finishPrecedingSetFont.getPrecedingPromise()
@@ -718,7 +718,7 @@ tachyfont.IncrementalFont.possibly_obfuscate = function(
 tachyfont.IncrementalFont.obj.prototype.loadChars = function() {
   var neededCodes = [];
 
-  var msg = this.fontInfo_.getName() + ' loadChars';
+  var msg = this.fontInfo_.getFontFamily() + ' loadChars';
   var finishPrecedingCharsRequest =
       this.finishPrecedingCharsRequest_.getChainedPromise(msg);
   return finishPrecedingCharsRequest.getPrecedingPromise()
@@ -904,7 +904,7 @@ tachyfont.IncrementalFont.obj.prototype.calcNeededChars = function() {
             neededCodes, charlist, this.loadableCodepoints_);
         if (goog.DEBUG) {
           tachyfont.log.info(
-              this.fontInfo_.getName() + ' ' + this.fontId_ + ': load ' +
+              this.fontInfo_.getFontFamily() + ' ' + this.fontId_ + ': load ' +
               neededCodes.length + ' codes:');
         }
         var remaining;

--- a/run_time/src/gae_server/www/js/tachyfont/incrementalfontutils.js
+++ b/run_time/src/gae_server/www/js/tachyfont/incrementalfontutils.js
@@ -210,11 +210,11 @@ tachyfont.IncrementalFontUtils.getBlobUrl = function(data, mimeType) {
 /**
  * Trim a CSSStyleSheet font-family string.
  *
- * @param {string} familyName The font-family name to trim.
+ * @param {string} cssFontFamily The font-family name to trim.
  * @return {string} The trimed font-family name.
  */
-tachyfont.IncrementalFontUtils.trimFamilyName = function(familyName) {
-  var trimmedName = familyName.trim();
+tachyfont.IncrementalFontUtils.trimCssFontFamily = function(cssFontFamily) {
+  var trimmedName = cssFontFamily.trim();
   // When there are spaces in the font-name, Chromium adds quotes
   // around the font name in the style object; eg, "Noto Sans Japanese"
   // becomes "'Noto Sans Japanese'".
@@ -255,7 +255,6 @@ tachyfont.IncrementalFontUtils.getStyleSheet = function() {
 
 /**
  * Delete a CSS style rule.
- *
  * @param {number} ruleToDelete The rule to delete.
  * @param {!CSSStyleSheet} sheet The style sheet.
  */
@@ -276,15 +275,14 @@ tachyfont.IncrementalFontUtils.deleteCssRule = function(ruleToDelete, sheet) {
 
 /**
  * Find the \@font-face rule for the given font spec.
- *
  * TODO(bstell): Add slant, width, etc.
  * @param {!CSSStyleSheet} sheet The style sheet.
- * @param {string} fontFamily The fontFamily.
+ * @param {string} cssFontFamily The cssFontFamily.
  * @param {string} weight The weight.
  * @return {number} The rule index; -1 if not found.
  */
-tachyfont.IncrementalFontUtils.findFontFaceRule =
-    function(sheet, fontFamily, weight) {
+tachyfont.IncrementalFontUtils.findFontFaceRule = function(
+    sheet, cssFontFamily, weight) {
   var rule = -1;
   var rules = sheet.cssRules || sheet.rules;
   if (rules) {
@@ -292,11 +290,12 @@ tachyfont.IncrementalFontUtils.findFontFaceRule =
       var this_rule = rules[i];
       if (this_rule.type == CSSRule.FONT_FACE_RULE) {
         var this_style = this_rule.style;
-        var thisFamily = this_style.getPropertyValue('font-family');
-        thisFamily = tachyfont.IncrementalFontUtils.trimFamilyName(thisFamily);
+        var thisCssFontFamily = this_style.getPropertyValue('font-family');
+        thisCssFontFamily =
+            tachyfont.IncrementalFontUtils.trimCssFontFamily(thisCssFontFamily);
         var thisWeight = this_style.getPropertyValue('font-weight');
         // TODO(bstell): consider using slant/width.
-        if (thisFamily == fontFamily && thisWeight == weight) {
+        if (thisCssFontFamily == cssFontFamily && thisWeight == weight) {
           rule = i;
           break;
         }
@@ -311,23 +310,21 @@ tachyfont.IncrementalFontUtils.findFontFaceRule =
  * Set the CSS \@font-face rule.
  *
  * @param {!CSSStyleSheet} sheet The style sheet.
- * @param {string} fontFamily The fontFamily.
+ * @param {string} cssFontFamily The cssFontFamily.
  * @param {string} weight The weight.
  * @param {string} blobUrl The blob URL of the font data.
  * @param {string} format The format (truetype vs opentype) of the font.
  */
-tachyfont.IncrementalFontUtils.setCssFontRule =
-    function(sheet, fontFamily, weight, blobUrl, format) {
+tachyfont.IncrementalFontUtils.setCssFontRule = function(
+    sheet, cssFontFamily, weight, blobUrl, format) {
   var rule_str = '@font-face {\n' +
-      '    font-family: ' + fontFamily + ';\n' +
+      '    font-family: ' + cssFontFamily + ';\n' +
       '    font-weight: ' + weight + ';\n' +
       '    src: url("' + blobUrl + '")' +
       ' format("' + format + '");\n' +
       '}\n';
   var ruleToDelete = tachyfont.IncrementalFontUtils.findFontFaceRule(
-      sheet, fontFamily, weight);
+      sheet, cssFontFamily, weight);
   tachyfont.IncrementalFontUtils.deleteCssRule(ruleToDelete, sheet);
   sheet.insertRule(rule_str, sheet.cssRules.length);
 };
-
-

--- a/run_time/src/gae_server/www/js/tachyfont/launcher.js
+++ b/run_time/src/gae_server/www/js/tachyfont/launcher.js
@@ -125,7 +125,7 @@
    * @constructor
    */
   launcher.FontInfo = function(fontFamily, weight, priority, isTtf) {
-    /** @type {string} The font name. */
+    /** @type {string} The font family name. */
     this.fontFamily = fontFamily;
 
     /** @type {string} The font weight. */
@@ -190,14 +190,14 @@
 
   /**
    * Loads the TachyFonts from persistent store if available.
-   * @param {string} fontFamily The font's family name.
-   * @param {string} cssFontFamily The CSS font-family name.
+   * @param {string} cssFontFamily The font's family name.
+   * @param {string} fontFamily The CSS font-family name.
    * @param {boolean} isTtf Whether is a TrueType or CFF type font.
    * @param {!Array<string>} weights The list of font weights to load.
    * @return {!Promise<boolean>} Resolves true if all the fonts were persisted.
    */
-  launcher.loadFonts = function(
-      cssFontFamily, fontFamily, isTtf, weights) {
+  launcher.loadFonts = function(cssFontFamily, fontFamily, isTtf, weights) {
+    debugger;
     var fontInfos = [];
     for (var i = 0; i < weights.length; i++) {
       fontInfos.push(
@@ -321,13 +321,14 @@
    * Set the CSS \@font-face rule.
    *
    * @param {!CSSStyleSheet} sheet The style sheet.
-   * @param {string} fontFamily The fontFamily.
+   * @param {string} cssFontFamily The fontFamily.
    * @param {string} weight The weight.
    * @param {string} srcStr The src string for the \@font-face
    */
-  function setCssFontRule(sheet, fontFamily, weight, srcStr) {
+  function setCssFontRule(sheet, cssFontFamily, weight, srcStr) {
+    debugger;
     var rule_str = '@font-face{' +
-        'font-family: ' + fontFamily + ';' +
+        'font-family: ' + cssFontFamily + ';' +
         'font-weight: ' + weight + ';' +
         'src: ' + srcStr +  //
         '}\n';
@@ -522,31 +523,33 @@
 
   /**
    * For the node and sub-nodes remove TachyFont from input fields.
-   * @param {string} fontFamily The TachyFont font family.
+   * @param {string} cssFontFamily The TachyFont font family.
    * @param {string} cssFontFamilyToAugment The font family to augment with
    *     TachyFont
    * @param {!Node} node The starting point for walking the node/sub-nodes.
    */
   launcher.recursivelyAdjustCssFontFamilies = function(
-      fontFamily, cssFontFamilyToAugment, node) {
-    launcher.adjustCssFontFamilies(fontFamily, cssFontFamilyToAugment, node);
+      cssFontFamily, cssFontFamilyToAugment, node) {
+    debugger;
+    launcher.adjustCssFontFamilies(cssFontFamily, cssFontFamilyToAugment, node);
     var children = node.childNodes;
     for (var i = 0; i < children.length; i++) {
       launcher.recursivelyAdjustCssFontFamilies(
-          fontFamily, cssFontFamilyToAugment, children[i]);
+          cssFontFamily, cssFontFamilyToAugment, children[i]);
     }
   };
 
 
   /**
    * Remove TachyFont from an input field.
-   * @param {string} fontFamily The TachyFont font family.
+   * @param {string} cssFontFamily The TachyFont font family.
    * @param {string} cssFontFamilyToAugment The font family to augment with
    *     TachyFont
    * @param {!Node} node The node to work on.
    */
   launcher.adjustCssFontFamilies = function(
-      fontFamily, cssFontFamilyToAugment, node) {
+      cssFontFamily, cssFontFamilyToAugment, node) {
+    debugger;
     if (node.nodeType != Node.ELEMENT_NODE) {
       return;
     }
@@ -556,24 +559,25 @@
     var families = cssFamily.split(',');
     var trimmedFamilies = [];
     for (var i = 0; i < families.length; i++) {
-      var name = launcher.trimFamilyName(families[i]);
+      var aCssFontName = launcher.trimCssFontFamily(families[i]);
       if (node.nodeName == 'INPUT') {
         // Drop TachyFont from input fields.
-        if (name == fontFamily) {
+        if (aCssFontName == cssFontFamily) {
           needToAdjustedCss = true;
         } else {
-          trimmedFamilies.push(name);
+          trimmedFamilies.push(aCssFontName);
         }
         continue;
       } else {
-        if (!cssFontFamilyToAugment || (name != cssFontFamilyToAugment)) {
-          trimmedFamilies.push(name);
+        if (!cssFontFamilyToAugment ||
+            (aCssFontName != cssFontFamilyToAugment)) {
+          trimmedFamilies.push(aCssFontName);
           continue;
         }
         // Check if this font is already augmented by TachyFont.
         if (i + 1 < families.length) {
-          var nextName = launcher.trimFamilyName(families[i + 1]);
-          if (nextName == fontFamily) {
+          var nextName = launcher.trimCssFontFamily(families[i + 1]);
+          if (nextName == cssFontFamily) {
             // Already augmented.
             continue;
           }
@@ -581,9 +585,9 @@
       }
       // Need to augment with TachyFont.
       needToAdjustedCss = true;
-      trimmedFamilies.push(name);
+      trimmedFamilies.push(aCssFontName);
       // Add TachyFont for this element.
-      trimmedFamilies.push(fontFamily);
+      trimmedFamilies.push(cssFontFamily);
     }
     if (needToAdjustedCss) {
       var newCssFamily = trimmedFamilies.join(', ');
@@ -606,11 +610,12 @@
   /**
    * Trim a CSSStyleSheet font-family string.
    *
-   * @param {string} familyName The font-family name to trim.
+   * @param {string} cssFontFamily The font-family name to trim.
    * @return {string} The trimed font-family name.
    */
-  launcher.trimFamilyName = function(familyName) {
-    var trimmedName = familyName.trim();
+  launcher.trimCssFontFamily = function(cssFontFamily) {
+    debugger;
+    var trimmedName = cssFontFamily.trim();
     var firstChar = trimmedName.charAt(0);
     var lastChar = trimmedName.charAt(trimmedName.length - 1);
     if (firstChar != lastChar) {

--- a/run_time/src/gae_server/www/js/tachyfont/merged_data.js
+++ b/run_time/src/gae_server/www/js/tachyfont/merged_data.js
@@ -185,7 +185,7 @@ tachyfont.MergedData.prototype.getInfo_ = function() {
 
 /**
  * Contains info about the merged data.
- * @param {string} familyName
+ * @param {string} fontFamily
  * @param {number} majorVersion
  * @param {number} minorVersion
  * @param {number} numberSubtables
@@ -195,10 +195,11 @@ tachyfont.MergedData.prototype.getInfo_ = function() {
  * @constructor @struct
  */
 tachyfont.MergedData.Info = function(
-    familyName, majorVersion, minorVersion, numberSubtables, primaryName,
+    fontFamily, majorVersion, minorVersion, numberSubtables, primaryName,
     subtableRecords) {
+  debugger;
   /** @type {string} */
-  this.familyName = familyName;
+  this.fontFamily = fontFamily;
 
   /** @type {number} */
   this.majorVersion = majorVersion;
@@ -260,8 +261,9 @@ tachyfont.MergedData.prototype.parseMergedData = function() {
   var numberSubtables = this.binaryEditor.getUint8();
 
   // Read the font family name.
-  var familyNamelength = this.binaryEditor.getUint8();
-  var familyName = this.binaryEditor.readString(familyNamelength);
+  debugger;
+  var fontFamilylength = this.binaryEditor.getUint8();
+  var fontFamily = this.binaryEditor.readString(fontFamilylength);
 
   var subtableRecords = {};
   var primaryName = '';
@@ -280,7 +282,7 @@ tachyfont.MergedData.prototype.parseMergedData = function() {
   }
 
   var info = new tachyfont.MergedData.Info(
-      familyName, majorVersion, minorVersion, numberSubtables, primaryName,
+      fontFamily, majorVersion, minorVersion, numberSubtables, primaryName,
       subtableRecords);
   return info;
 };

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfont.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfont.js
@@ -212,13 +212,13 @@ tachyfont.reportError = function(errNum, opt_errInfo, opt_fontId) {
 
 /**
  * Load a list of TachyFonts
- * @param {string} cssFamilyName The font-family name.
+ * @param {string} cssFontFamily The CSS font-family name.
  * @param {!tachyfont.FontsInfo} fontsInfo Information about the fonts.
  * @param {!Object<string, string>=} opt_params Optional parameters.
  * @return {!goog.Promise<?tachyfont.TachyFontSet,?>} A promise that returns the
  *     TachyFontSet object or null if the fonts are not loaded.
  */
-tachyfont.loadFonts = function(cssFamilyName, fontsInfo, opt_params) {
+tachyfont.loadFonts = function(cssFontFamily, fontsInfo, opt_params) {
   var params = opt_params || {};
   if (goog.DEBUG) {
     tachyfont.debugInitialization_();
@@ -243,7 +243,7 @@ tachyfont.loadFonts = function(cssFamilyName, fontsInfo, opt_params) {
       .then(function(mergedFontbasesBytes) {
         // Initialize the objects.
         var tachyFontSet =
-            tachyfont.loadFonts_init_(cssFamilyName, fontsInfo, params);
+            tachyfont.loadFonts_init_(cssFontFamily, fontsInfo, params);
         // Load the fonts.
         var xdelta3Decoder = launcherInfo.getXDeltaDecoder();
         var fontbases =
@@ -633,7 +633,7 @@ tachyfont.loadFonts_initReporter = function(fontsInfo) {
 
 /**
  * Initialization before loading a list of TachyFonts
- * @param {string} familyName The font-family name.
+ * @param {string} cssFontFamily The font-family name.
  * TODO(bstell): remove the Object type.
  * @param {!tachyfont.FontsInfo} fontsInfo The information about the
  *     fonts.
@@ -641,21 +641,21 @@ tachyfont.loadFonts_initReporter = function(fontsInfo) {
  * @return {!tachyfont.TachyFontSet} The TachyFontSet object.
  * @private
  */
-tachyfont.loadFonts_init_ = function(familyName, fontsInfo, params) {
+tachyfont.loadFonts_init_ = function(cssFontFamily, fontsInfo, params) {
   var dataUrl = fontsInfo.getDataUrl();
   var cssFontFamilyToAugment = params['cssFontFamilyToAugment'] || '';
 
   var tachyFontSet =
-      new tachyfont.TachyFontSet(familyName, cssFontFamilyToAugment);
+      new tachyfont.TachyFontSet(cssFontFamily, cssFontFamilyToAugment);
   var fontInfos = fontsInfo.getPrioritySortedFonts();
   for (var i = 0; i < fontInfos.length; i++) {
     var fontInfo = fontInfos[i];
-    fontInfo.setFamilyName(familyName);
+    fontInfo.setCssFontFamily(cssFontFamily);
     fontInfo.setDataUrl(dataUrl);
     var tachyFont = new tachyfont.TachyFont(fontInfo, params);
     tachyFontSet.addFont(tachyFont);
     // TODO(bstell): need to support slant/width/etc.
-    var fontId = tachyfont.utils.fontId(familyName, fontInfo.getWeight());
+    var fontId = tachyfont.utils.fontId(cssFontFamily, fontInfo.getWeight());
     tachyFontSet.fontIdToIndex[fontId] = i;
   }
   return tachyFontSet;

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfontset.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfontset.js
@@ -31,11 +31,11 @@ goog.require('tachyfont.utils');
 
 /**
  * Manage a group of TachyFonts.
- * @param {string} familyName The font family name for this set.
+ * @param {string} cssFontFamily The font family name for this set.
  * @param {string} cssFontFamilyToAugment The cssFontFamily to augment.
  * @constructor @struct
  */
-tachyfont.TachyFontSet = function(familyName, cssFontFamilyToAugment) {
+tachyfont.TachyFontSet = function(cssFontFamily, cssFontFamilyToAugment) {
   /**
    * The TachyFonts managed in this set.
    * @type {!Array<!tachyfont.TachyFont>}
@@ -55,7 +55,7 @@ tachyfont.TachyFontSet = function(familyName, cssFontFamilyToAugment) {
   this.cssFontFamilyToAugment = cssFontFamilyToAugment;
 
   /** @type {string} */
-  this.familyName = familyName;
+  this.cssFontFamily = cssFontFamily;
 
   /**
    * Sigh, for really slow sites do not set the CSS until the page is loaded.
@@ -232,26 +232,27 @@ tachyfont.TachyFontSet.prototype.adjustCssFontFamilies = function(node) {
   var families = cssFamily.split(',');
   var trimmedFamilies = [];
   for (var i = 0; i < families.length; i++) {
-    var name = tachyfont.IncrementalFontUtils.trimFamilyName(families[i]);
+    var cssFontFamily =
+        tachyfont.IncrementalFontUtils.trimCssFontFamily(families[i]);
     if (node.nodeName == 'INPUT') {
       // Drop TachyFont from input fields.
-      if (name == this.familyName) {
+      if (cssFontFamily == this.cssFontFamily) {
         needToAdjustedCss = true;
       } else {
-        trimmedFamilies.push(name);
+        trimmedFamilies.push(cssFontFamily);
       }
       continue;
     } else {
       if (!this.cssFontFamilyToAugment ||
-          (name != this.cssFontFamilyToAugment)) {
-        trimmedFamilies.push(name);
+          (cssFontFamily != this.cssFontFamilyToAugment)) {
+        trimmedFamilies.push(cssFontFamily);
         continue;
       }
       // Check if this font is already augmented by TachyFont.
       if (i + 1 < families.length) {
         var nextName =
-            tachyfont.IncrementalFontUtils.trimFamilyName(families[i + 1]);
-        if (nextName == this.familyName) {
+            tachyfont.IncrementalFontUtils.trimCssFontFamily(families[i + 1]);
+        if (nextName == this.cssFontFamily) {
           // Already augmented.
           continue;
         }
@@ -259,9 +260,9 @@ tachyfont.TachyFontSet.prototype.adjustCssFontFamilies = function(node) {
     }
     // Need to augment with TachyFont.
     needToAdjustedCss = true;
-    trimmedFamilies.push(name);
+    trimmedFamilies.push(cssFontFamily);
     // Add TachyFont for this element.
-    trimmedFamilies.push(this.familyName);
+    trimmedFamilies.push(this.cssFontFamily);
   }
   if (needToAdjustedCss) {
     var newCssFamily = trimmedFamilies.join(', ');
@@ -320,9 +321,10 @@ tachyfont.TachyFontSet.prototype.addTextToFontGroups = function(node) {
   if (family == undefined) {
     var families = cssFamily.split(',');
     for (var i = 0; i < families.length; i++) {
-      var aFamily = tachyfont.IncrementalFontUtils.trimFamilyName(families[i]);
-      if (aFamily == this.familyName) {
-        this.cssFamilyToTachyFontFamily[cssFamily] = this.familyName;
+      var aCssFontFamily =
+          tachyfont.IncrementalFontUtils.trimCssFontFamily(families[i]);
+      if (aCssFontFamily == this.cssFontFamily) {
+        this.cssFamilyToTachyFontFamily[cssFamily] = this.cssFontFamily;
         break;
       }
     }

--- a/run_time/src/gae_server/www/js/tachyfont/webfonttailor.js
+++ b/run_time/src/gae_server/www/js/tachyfont/webfonttailor.js
@@ -31,14 +31,14 @@ goog.require('tachyfont.webfonttailor_alternate');
  * @private {!Object<string, !Object<string, string>>}
  */
 tachyfont.webfonttailor.JaNormalInfo_ = {
-  'familyName': { 'name': 'Noto Sans JP' },
-  '100': { 'name': 'NotoSansJP-Thin', 'weight': '100' },
-  '300': { 'name': 'NotoSansJP-Light', 'weight': '300' },
-  '350': { 'name': 'NotoSansJP-DemiLight', 'weight': '350' },
-  '400': { 'name': 'NotoSansJP-Regular', 'weight': '400' },
-  '500': { 'name': 'NotoSansJP-Medium', 'weight': '500' },
-  '700': { 'name': 'NotoSansJP-Bold', 'weight': '700' },
-  '900': { 'name': 'NotoSansJP-Black', 'weight': '900' }
+  'fontFamily': {'name': 'Noto Sans JP'},
+  '100': {'name': 'NotoSansJP-Thin', 'weight': '100'},
+  '300': {'name': 'NotoSansJP-Light', 'weight': '300'},
+  '350': {'name': 'NotoSansJP-DemiLight', 'weight': '350'},
+  '400': {'name': 'NotoSansJP-Regular', 'weight': '400'},
+  '500': {'name': 'NotoSansJP-Medium', 'weight': '500'},
+  '700': {'name': 'NotoSansJP-Bold', 'weight': '700'},
+  '900': {'name': 'NotoSansJP-Black', 'weight': '900'}
 };
 
 
@@ -116,8 +116,8 @@ tachyfont.webfonttailor.getTachyFontsInfo =
           var font = weightsInfo[weight];
           if (font) {
             var priority = priorityWeights.indexOf(weight) != -1;
-            var fontInfo = new tachyfont.FontInfo(weightsInfo.familyName.name,
-                font['weight'], priority);
+            var fontInfo = new tachyfont.FontInfo(
+                weightsInfo.fontFamily.name, font['weight'], priority);
             if (priority) {
               priorityFonts.push(fontInfo);
             } else {


### PR DESCRIPTION
Change familyName to cssFontFamily when it is used for the CSS font-family.
Change familyName to fontFamily when it is the font's family name.