### PR TITLE
Prepare metric/error reporting to be backend specific.

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/error_report.js
+++ b/run_time/src/gae_server/www/js/tachyfont/error_report.js
@@ -1,0 +1,78 @@
+'use strict';
+
+/**
+ * @license
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+goog.provide('tachyfont.ErrorReport');
+
+
+
+/**
+ * The ErrorReport class contains a single error report.
+ * @param {string} errorId The error identifier.
+ * @param {string} fontId The font identifier.
+ * @param {string} errorDetail The error details.
+ * @constructor @struct @final
+ */
+tachyfont.ErrorReport = function(errorId, fontId, errorDetail) {
+  /**
+   * The error identifier.
+   * @private {string}
+   */
+  this.errorId_ = errorId;
+
+  /**
+   * The font identifier.
+   * @private {string}
+   */
+  this.fontId_ = fontId;
+
+  /**
+   * Details about the error.
+   * @private {string}
+   */
+  this.errorDetail_ = errorDetail;
+
+};
+
+
+/**
+ * Gets the error id.
+ * @return {string}
+ */
+tachyfont.ErrorReport.prototype.getErrorId = function() {
+  return this.errorId_;
+};
+
+
+/**
+ * Gets the font id.
+ * @return {string}
+ */
+tachyfont.ErrorReport.prototype.getFontId = function() {
+  return this.fontId_;
+};
+
+
+/**
+ * Gets the error detail.
+ * @return {string}
+ */
+tachyfont.ErrorReport.prototype.getErrorDetail = function() {
+  return this.errorDetail_;
+};

--- a/run_time/src/gae_server/www/js/tachyfont/incrementalfont.js
+++ b/run_time/src/gae_server/www/js/tachyfont/incrementalfont.js
@@ -126,7 +126,7 @@ tachyfont.IncrementalFont.createManager = function(fontInfo, backend, params) {
   var incrFontMgr =
       new tachyfont.IncrementalFont.obj(fontInfo, params, backend);
   tachyfont.Reporter.addItem(
-      tachyfont.IncrementalFont.Log.CREATE_TACHYFONT + fontId,
+      tachyfont.IncrementalFont.Log.CREATE_TACHYFONT, fontId,
       goog.now() - incrFontMgr.startTime_);
 
   return incrFontMgr;
@@ -509,7 +509,7 @@ tachyfont.IncrementalFont.obj.prototype.getCompactFontFromMergedData = function(
 tachyfont.IncrementalFont.obj.prototype.processFontbase = function(
     urlBaseBytes) {
   tachyfont.Reporter.addItem(
-      tachyfont.IncrementalFont.Log.URL_GET_BASE + this.fontId_,
+      tachyfont.IncrementalFont.Log.URL_GET_BASE, this.fontId_,
       goog.now() - this.startTime_);
   var results = tachyfont.IncrementalFont.processUrlBase(
       urlBaseBytes, this.fontId_, true);
@@ -894,9 +894,9 @@ tachyfont.IncrementalFont.obj.prototype.calcNeededChars = function() {
         var missCount = neededCodes.length;
         var missRate = (neededCodes.length * 100) / charArray.length;
         tachyfont.Reporter.addItem(
-            tachyfont.IncrementalFont.Log.MISS_COUNT + this.fontId_, missCount);
+            tachyfont.IncrementalFont.Log.MISS_COUNT, this.fontId_, missCount);
         tachyfont.Reporter.addItem(
-            tachyfont.IncrementalFont.Log.MISS_RATE + this.fontId_, missRate);
+            tachyfont.IncrementalFont.Log.MISS_RATE, this.fontId_, missRate);
         if (neededCodes.length == 0) {
           return goog.Promise.resolve(neededCodes);
         }

--- a/run_time/src/gae_server/www/js/tachyfont/metric_report.js
+++ b/run_time/src/gae_server/www/js/tachyfont/metric_report.js
@@ -1,0 +1,78 @@
+'use strict';
+
+/**
+ * @license
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+goog.provide('tachyfont.MetricReport');
+
+
+
+/**
+ * The MetricReport class contains a single metric report.
+ * @param {string} metricId The metric identifier.
+ * @param {string} fontId The font identifier.
+ * @param {number} metricValue The metric value. This will be rounded.
+ * @constructor @struct @final
+ */
+tachyfont.MetricReport = function(metricId, fontId, metricValue) {
+  /**
+   * The metric identifier.
+   * @private {string}
+   */
+  this.metricId_ = metricId;
+
+  /**
+   * The font identifier.
+   * @private {string}
+   */
+  this.fontId_ = fontId;
+
+  /**
+   * The metric value.
+   * @private {number}
+   */
+  this.metricValue_ = Math.round(metricValue);
+
+};
+
+
+/**
+ * Gets the metric id.
+ * @return {string}
+ */
+tachyfont.MetricReport.prototype.getMetricId = function() {
+  return this.metricId_;
+};
+
+
+/**
+ * Gets the font id.
+ * @return {string}
+ */
+tachyfont.MetricReport.prototype.getFontId = function() {
+  return this.fontId_;
+};
+
+
+/**
+ * Gets the metric value.
+ * @return {number}
+ */
+tachyfont.MetricReport.prototype.getMetricValue = function() {
+  return this.metricValue_;
+};

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfont.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfont.js
@@ -347,7 +347,7 @@ tachyfont.sendLauncherReports = function(launcherInfo) {
     } else if (reportType == 'l') {  // Log report.
       var time = report[1];
       // LINT.IfChange
-      tachyfont.Reporter.addItem('LPLLT.' + id, time);
+      tachyfont.Reporter.addItem('LPLLT.', id, parseInt(time, 10));
       // LINT.ThenChange(//depot/google3/\
       //     java/com/google/i18n/tachyfont/http/error-reports.properties)
     }
@@ -558,7 +558,7 @@ tachyfont.loadFonts_loadAndUse_ = function(tachyFontSet, fontbases) {
   return waitForPrecedingPromise.getPrecedingPromise()
       .then(function() {
         tachyfont.Reporter.addItem(
-            tachyfont.Log_.LOAD_FONTS_WAIT_PREVIOUS + '000',
+            tachyfont.Log_.LOAD_FONTS_WAIT_PREVIOUS, '000',
             goog.now() - waitPreviousTime);
         var serialPromise = goog.Promise.resolve(0);
         var fonts = tachyFontSet.fonts;
@@ -639,7 +639,7 @@ tachyfont.loadFonts_initFontInfosUrls = function(fontsInfo) {
 tachyfont.loadFonts_initReporter = function(fontsInfo) {
   var reportUrl = fontsInfo.getReportUrl();
   tachyfont.Reporter.initReporter(reportUrl, fontsInfo.getApiVersion());
-  tachyfont.Reporter.addItemTime(tachyfont.Log_.LOAD_FONTS + '000');
+  tachyfont.Reporter.addItemTime(tachyfont.Log_.LOAD_FONTS, '000');
 };
 
 

--- a/run_time/src/gae_server/www/js/tachyfont/tachyfontset.js
+++ b/run_time/src/gae_server/www/js/tachyfont/tachyfontset.js
@@ -425,7 +425,7 @@ tachyfont.TachyFontSet.prototype.updateFonts =
       .then(
           function() {
             tachyfont.Reporter.addItem(
-                tachyfont.TachyFontSet.Log.SET_FONT + '000',
+                tachyfont.TachyFontSet.Log.SET_FONT, '000',
                 goog.now() - startTime);
             tachyfont.Reporter.sendReport();
           },


### PR DESCRIPTION
Create metric and error report objects.
Pass error id separately from font id.
Modify the reporter code to use the metric/error objects.