### PR TITLE
Protect the field names from being changed by the compiler.

### DIFF
--- a/run_time/src/gae_server/www/js/tachyfont/error_report.js
+++ b/run_time/src/gae_server/www/js/tachyfont/error_report.js
@@ -27,7 +27,7 @@ goog.provide('tachyfont.ErrorReport');
  * @param {string} errorId The error identifier.
  * @param {string} fontId The font identifier.
  * @param {string} errorDetail The error details.
- * @constructor @struct @final
+ * @constructor @final
  */
 tachyfont.ErrorReport = function(errorId, fontId, errorDetail) {
   // LINT.IfChange
@@ -36,21 +36,21 @@ tachyfont.ErrorReport = function(errorId, fontId, errorDetail) {
    * Note: this field name needs to match the proto's field name.
    * @type {string}
    */
-  this.error_id = errorId;
+  this['error_id'] = errorId;
 
   /**
    * The font identifier.
    * Note: this field name needs to match the proto's field name.
    * @type {string}
    */
-  this.font_id = fontId;
+  this['font_id'] = fontId;
 
   /**
    * Details about the error.
    * Note: this field name needs to match the proto's field name.
    * @type {string}
    */
-  this.error_info = errorDetail;
+  this['error_info'] = errorDetail;
   // LINT.ThenChange(//depot/google3/\
   //     google/internal/incrementalwebfonts/v1/tachyfont.proto)
 };
@@ -61,7 +61,7 @@ tachyfont.ErrorReport = function(errorId, fontId, errorDetail) {
  * @return {string}
  */
 tachyfont.ErrorReport.prototype.getErrorId = function() {
-  return this.error_id;
+  return this['error_id'];
 };
 
 
@@ -70,7 +70,7 @@ tachyfont.ErrorReport.prototype.getErrorId = function() {
  * @return {string}
  */
 tachyfont.ErrorReport.prototype.getFontId = function() {
-  return this.font_id;
+  return this['font_id'];
 };
 
 
@@ -79,5 +79,5 @@ tachyfont.ErrorReport.prototype.getFontId = function() {
  * @return {string}
  */
 tachyfont.ErrorReport.prototype.getErrorDetail = function() {
-  return this.error_info;
+  return this['error_info'];
 };

--- a/run_time/src/gae_server/www/js/tachyfont/metric_report.js
+++ b/run_time/src/gae_server/www/js/tachyfont/metric_report.js
@@ -27,7 +27,7 @@ goog.provide('tachyfont.MetricReport');
  * @param {string} metricId The metric identifier.
  * @param {string} fontId The font identifier.
  * @param {number} metricValue The metric value. This will be rounded.
- * @constructor @struct @final
+ * @constructor @final
  */
 tachyfont.MetricReport = function(metricId, fontId, metricValue) {
   // LINT.IfChange
@@ -36,21 +36,21 @@ tachyfont.MetricReport = function(metricId, fontId, metricValue) {
    * Note: this field name needs to match the proto's field name.
    * @type {string}
    */
-  this.metric_id = metricId;
+  this['metric_id'] = metricId;
 
   /**
    * The font identifier.
    * Note: this field name needs to match the proto's field name.
    * @type {string}
    */
-  this.font_id = fontId;
+  this['font_id'] = fontId;
 
   /**
    * The metric value.
    * Note: this field name needs to match the proto's field name.
    * @type {number}
    */
-  this.value = Math.round(metricValue);
+  this['value'] = Math.round(metricValue);
   // LINT.ThenChange(//depot/google3/\
   //     google/internal/incrementalwebfonts/v1/tachyfont.proto)
 };
@@ -61,7 +61,7 @@ tachyfont.MetricReport = function(metricId, fontId, metricValue) {
  * @return {string}
  */
 tachyfont.MetricReport.prototype.getMetricId = function() {
-  return this.metric_id;
+  return this['metric_id'];
 };
 
 
@@ -70,7 +70,7 @@ tachyfont.MetricReport.prototype.getMetricId = function() {
  * @return {string}
  */
 tachyfont.MetricReport.prototype.getFontId = function() {
-  return this.font_id;
+  return this['font_id'];
 };
 
 
@@ -79,5 +79,5 @@ tachyfont.MetricReport.prototype.getFontId = function() {
  * @return {number}
  */
 tachyfont.MetricReport.prototype.getMetricValue = function() {
-  return this.value;
+  return this['value'];
 };


### PR DESCRIPTION
The field names need to match the protobuf field names.